### PR TITLE
chore: update README and formula for kompo-vfs library

### DIFF
--- a/Formula/kompo-vfs.rb
+++ b/Formula/kompo-vfs.rb
@@ -1,20 +1,21 @@
 class KompoVfs < Formula
-  desc ""
+  desc "Virtual filesystem library for kompo gem"
   homepage "https://github.com/ahogappa0613/kompo-vfs"
   url "https://github.com/ahogappa0613/kompo-vfs.git", using: :git, branch: "main"
   head "https://github.com/ahogappa0613/kompo-vfs.git", branch: "main"
-  version "0.1.0"
+  version "0.2.0"
 
   depends_on "rust" => :build
 
   def install
     system "cargo build --release"
 
-    lib.install "target/release/libkompo.a"
+    lib.install "target/release/libkompo_fs.a"
+    lib.install "target/release/libkompo_wrap.a"
   end
 
   test do
-    system bin/"kompo-cli", "--version"
-    system "file", lib/"libkompo.a"
+    system "file", lib/"libkompo_fs.a"
+    system "file", lib/"libkompo_wrap.a"
   end
 end

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-kompo-vfs is the CLI and library used with the kompo gem.
+kompo-vfs is library used with the kompo gem.


### PR DESCRIPTION
- Updated README to clarify that kompo-vfs is a library.
- Enhanced formula description to specify it as a virtual filesystem library.
- Bumped version from 0.1.0 to 0.2.0.
- Changed installed library names to libkompo_fs.a and libkompo_wrap.a.