### PR TITLE
feat: add getattrlist syscall support for macOS and improve documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .DS_Store
+.serena

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,7 @@
 
 members = ["kompo_fs", "kompo_storage", "kompo_wrap", "kompo_fs/kompo_fs_test_data"]
 resolver = "2"
+
+[profile.release]
+panic = "abort"
+lto = true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,96 @@
-kompo-vfs is library used with the kompo gem.
+# kompo-vfs
+
+A virtual filesystem library written in Rust for the [kompo](https://github.com/ahogappa/kompo) gem. This library enables Ruby scripts and their dependencies to be packed into a single binary by providing a virtual filesystem layer that intercepts system calls.
+
+## Overview
+
+kompo-vfs consists of three main components:
+
+| Crate | Description |
+|-------|-------------|
+| `kompo_fs` | Core virtual filesystem implementation using a trie data structure for efficient path lookup |
+| `kompo_storage` | Storage layer that manages file data and directory entries |
+| `kompo_wrap` | System call wrapper that intercepts and redirects filesystem operations |
+
+### How It Works
+
+kompo-vfs hooks into system calls (`open`, `read`, `stat`, `opendir`, etc.) to transparently redirect file operations. When the packed binary runs:
+
+1. The virtual filesystem is initialized with embedded file data
+2. System calls are intercepted and checked against the virtual filesystem
+3. If the path exists in the VFS, the operation is handled internally
+4. Otherwise, the call falls through to the real filesystem
+
+## Installation
+
+### Homebrew (Recommended)
+
+```sh
+$ brew tap ahogappa/kompo-vfs https://github.com/ahogappa/kompo-vfs.git
+$ brew install ahogappa/kompo-vfs/kompo-vfs
+```
+
+### Building from Source
+
+Prerequisites:
+- [Rust](https://rustup.rs/) (stable)
+
+```sh
+$ git clone https://github.com/ahogappa/kompo-vfs.git
+$ cd kompo-vfs
+$ cargo build --release
+```
+
+The built static libraries will be at:
+- `target/release/libkompo_fs.a`
+- `target/release/libkompo_wrap.a`
+
+## Usage
+
+This library is designed to be used with the [kompo](https://github.com/ahogappa/kompo) gem. See the kompo documentation for details on packing Ruby applications into single binaries.
+
+## Supported Platforms
+
+| Platform | Status |
+|----------|--------|
+| macOS (ARM) | ✅ Supported |
+| macOS (x64) | ❓ Untested |
+| Linux (x64) | ✅ Supported |
+| Linux (ARM) | ❓ Untested |
+| Windows | 🚧 Not yet supported |
+
+## Development
+
+### Running Tests
+
+```sh
+$ cargo test -p kompo_storage -p kompo_fs
+```
+
+### Project Structure
+
+```
+kompo-vfs/
+├── kompo_fs/           # Core VFS implementation
+│   └── src/
+│       └── lib.rs      # Trie-based filesystem, Ruby bindings
+├── kompo_storage/      # Storage layer
+│   └── src/
+│       └── lib.rs      # File/directory data management
+├── kompo_wrap/         # System call wrappers
+│   └── src/
+│       └── lib.rs      # Intercepts open, read, stat, etc.
+└── Formula/            # Homebrew formula
+```
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/ahogappa/kompo-vfs.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## Related Projects
+
+- [kompo](https://github.com/ahogappa/kompo) - Ruby gem that uses kompo-vfs to pack Ruby applications into single binaries


### PR DESCRIPTION
## Summary
- Add `getattrlist` syscall hook for macOS to handle `ATTR_CMN_NAME` and `ATTR_CMN_OBJTYPE` attributes
- Refactor `mkdir_from_fs` to use inner function pattern for consistency
- Improve README with comprehensive project documentation (installation, usage, structure)
- Add release profile optimizations (`panic=abort`, `lto=true`)
- Refactor directory entry deduplication logic and simplify `open`/`open_at` methods

## Test plan
- [x] All existing tests pass (`cargo test -p kompo_storage -p kompo_fs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)