### PR TITLE
feat: add kompo_fs_set_entrypoint_dir function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +22,12 @@ checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "shlex",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "crossbeam-deque"
@@ -68,6 +80,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +134,7 @@ dependencies = [
  "kompo_storage",
  "kompo_wrap",
  "libc",
+ "serial_test",
  "trie-rs",
 ]
 
@@ -120,12 +169,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "louds-rs"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936de6c22f08e7135a921f8ada907acd0d88880c4f42b5591f634b9f1dd8e07f"
 dependencies = [
  "fid-rs",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -149,10 +272,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "serial_test"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "syn"
+version = "2.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "trie-rs"
@@ -162,6 +364,18 @@ checksum = "f6f88f4b0a1ebd6c3d16be3e45eb0e8089372ccadd88849b7ca162ba64b5e6f6"
 dependencies = [
  "louds-rs",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"

--- a/Formula/kompo-vfs.rb
+++ b/Formula/kompo-vfs.rb
@@ -3,7 +3,7 @@ class KompoVfs < Formula
   homepage "https://github.com/ahogappa/kompo-vfs"
   url "https://github.com/ahogappa/kompo-vfs.git", using: :git, branch: "main"
   head "https://github.com/ahogappa/kompo-vfs.git", branch: "main"
-  version "0.3.0"
+  version "0.4.0"
 
   depends_on "rust" => :build
 

--- a/kompo_fs/Cargo.toml
+++ b/kompo_fs/Cargo.toml
@@ -17,6 +17,7 @@ errno = "*"
 
 [dev-dependencies]
 kompo_fs_test_data = { path = "./kompo_fs_test_data" }
+serial_test = "3"
 
 
 [profile.release]

--- a/kompo_fs/src/lib.rs
+++ b/kompo_fs/src/lib.rs
@@ -174,6 +174,7 @@ mod tests {
     extern crate kompo_fs_test_data;
 
     use super::*;
+    use serial_test::serial;
     use std::ffi::CString;
 
     #[test]
@@ -401,5 +402,59 @@ mod tests {
             stat_buf.st_mode & libc::S_IFDIR != 0,
             "Should be a directory"
         );
+    }
+
+    #[test]
+    #[serial]
+    fn test_kompo_fs_set_entrypoint_dir_with_valid_path() {
+        let path = CString::new("/app/bin/main.rb").unwrap();
+
+        unsafe {
+            // Clear WORKING_DIR before test
+            WORKING_DIR.take();
+
+            kompo_fs_set_entrypoint_dir(path.as_ptr());
+
+            // Verify WORKING_DIR is set to the parent directory
+            let working_dir = WORKING_DIR.take();
+            assert!(working_dir.is_some());
+            let dir_path = working_dir.unwrap();
+            assert_eq!(dir_path.to_str().unwrap(), "/app/bin");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_kompo_fs_set_entrypoint_dir_with_null() {
+        unsafe {
+            // Clear WORKING_DIR before test
+            WORKING_DIR.take();
+
+            // Should not panic when passing null
+            kompo_fs_set_entrypoint_dir(std::ptr::null());
+
+            // Verify WORKING_DIR is still None
+            let working_dir = WORKING_DIR.take();
+            assert!(working_dir.is_none());
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_kompo_fs_set_entrypoint_dir_with_root_path() {
+        let path = CString::new("/main.rb").unwrap();
+
+        unsafe {
+            // Clear WORKING_DIR before test
+            WORKING_DIR.take();
+
+            kompo_fs_set_entrypoint_dir(path.as_ptr());
+
+            // Verify WORKING_DIR is set to root
+            let working_dir = WORKING_DIR.take();
+            assert!(working_dir.is_some());
+            let dir_path = working_dir.unwrap();
+            assert_eq!(dir_path.to_str().unwrap(), "/");
+        }
     }
 }

--- a/kompo_fs/src/lib.rs
+++ b/kompo_fs/src/lib.rs
@@ -153,6 +153,22 @@ pub unsafe extern "C-unwind" fn Init_kompo_fs() {
     rb_define_singleton_method(class, is_context.as_ptr(), is_context_func, 0);
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn kompo_fs_set_entrypoint_dir(entrypoint_path: *const libc::c_char) {
+    if entrypoint_path.is_null() {
+        return;
+    }
+
+    let path_cstr = CStr::from_ptr(entrypoint_path);
+    let path = Path::new(path_cstr.to_str().expect("invalid entrypoint path"));
+
+    if let Some(parent) = path.parent() {
+        let parent_os_str = parent.as_os_str().to_os_string();
+        let cow = std::borrow::Cow::Owned(parent_os_str);
+        WORKING_DIR.replace(Some(cow));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     extern crate kompo_fs_test_data;


### PR DESCRIPTION
## Summary
- Add `kompo_fs_set_entrypoint_dir` C-exported function to set WORKING_DIR from an entrypoint path
- Bump Formula version from 0.3.0 to 0.4.0
- Add unit tests for the new function with `serial_test` crate

## Test plan
- [x] `cargo test -p kompo_fs` passes all 31 tests
- [x] `cargo build --release` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)