### PR TITLE
feat: upgrade to Rust 2024 edition with thread-safe improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .DS_Store
 .serena
+CLAUDE.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,17 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "cc"
-version = "1.2.18"
+version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
+checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -62,9 +57,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
@@ -78,6 +73,12 @@ checksum = "a6956a1e60e2d1412b44b4169d44a03dae518f8583d3e10090c912c105e48447"
 dependencies = [
  "rayon",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "futures-core"
@@ -116,24 +117,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "kompo_fs"
 version = "0.1.0"
 dependencies = [
  "errno",
- "fxhash",
  "kompo_fs_test_data",
  "kompo_storage",
  "kompo_wrap",
  "libc",
+ "rustc-hash",
  "serial_test",
  "trie-rs",
 ]
@@ -150,8 +142,8 @@ dependencies = [
 name = "kompo_storage"
 version = "0.1.0"
 dependencies = [
- "fxhash",
  "libc",
+ "rustc-hash",
  "trie-rs",
 ]
 
@@ -160,13 +152,14 @@ name = "kompo_wrap"
 version = "0.1.0"
 dependencies = [
  "libc",
+ "paste",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "lock_api"
@@ -222,6 +215,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,27 +234,27 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -263,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -279,6 +278,12 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "scc"
@@ -379,73 +384,9 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/kompo_fs/Cargo.toml
+++ b/kompo_fs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kompo_fs"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
@@ -10,7 +10,7 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 libc = "0.2.169"
 trie-rs = "0.4.2"
-fxhash = "0.2.1"
+rustc-hash = "2"
 kompo_storage = { path = "../kompo_storage" }
 kompo_wrap = { path = "../kompo_wrap" } 
 errno = "*"

--- a/kompo_fs/kompo_fs_test_data/Cargo.toml
+++ b/kompo_fs/kompo_fs_test_data/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kompo_fs_test_data"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 links = "kompo_test_data"
 
 [dependencies]

--- a/kompo_fs/kompo_fs_test_data/src/lib.rs
+++ b/kompo_fs/kompo_fs_test_data/src/lib.rs
@@ -2,7 +2,7 @@
 // The symbols are defined in dummy_fs.c and compiled by build.rs.
 
 #[allow(dead_code)]
-extern "C" {
+unsafe extern "C" {
     pub static PATHS: libc::c_char;
     pub static PATHS_SIZE: libc::c_int;
     pub static FILES: libc::c_char;

--- a/kompo_storage/Cargo.toml
+++ b/kompo_storage/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "kompo_storage"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 libc = "0.2.169"
 trie-rs = "0.4.2"
-fxhash = "0.2.1"
+rustc-hash = "2"

--- a/kompo_storage/src/lib.rs
+++ b/kompo_storage/src/lib.rs
@@ -1,4 +1,4 @@
-use fxhash::FxHasher;
+use rustc_hash::FxHasher;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ffi::OsStr;
@@ -44,8 +44,8 @@ fn convert_byte(b: &u8) -> u8 {
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 type DirEntryName = [i8; 256];
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-fn convert_byte(b: u8) -> i8 {
-    b as i8
+fn convert_byte(b: &u8) -> i8 {
+    *b as i8
 }
 
 #[cfg(target_os = "macos")]
@@ -377,11 +377,7 @@ impl<'a> Fs<'a> {
     fn create_dirent(inode: u64, file_type: u8, full_path: Vec<&OsStr>) -> libc::dirent {
         let mut buf: DirEntryName = [0; 256];
         let last_path = full_path.last().unwrap();
-        let convert_path: Vec<_> = last_path
-            .as_bytes()
-            .iter()
-            .map(|b| convert_byte(*b))
-            .collect();
+        let convert_path: Vec<_> = last_path.as_bytes().iter().map(convert_byte).collect();
         buf[..last_path.len()].copy_from_slice(&convert_path);
 
         libc::dirent {

--- a/kompo_wrap/Cargo.toml
+++ b/kompo_wrap/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "kompo_wrap"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 libc = "0.2.169"
+paste = "1.0"
 
 [lib]
 crate-type = ["staticlib", "rlib"]

--- a/kompo_wrap/src/lib.rs
+++ b/kompo_wrap/src/lib.rs
@@ -1,808 +1,80 @@
-// use kompo_fs::*;
-use std::collections::HashMap;
+use paste::paste;
 
-#[allow(dead_code)]
-fn initialize_thread_context(
-) -> std::sync::Arc<std::sync::RwLock<std::collections::HashMap<libc::pthread_t, bool>>> {
-    let mut thread_context = HashMap::new();
-    thread_context.insert(unsafe { libc::pthread_self() }, false);
-    std::sync::Arc::new(std::sync::RwLock::new(thread_context))
+/// Macro to define a syscall hook with HANDLE, extern declaration, and wrapper function.
+///
+/// Usage:
+/// - With return type: `syscall_hook!(open, (path: *const libc::c_char, oflag: libc::c_int) -> libc::c_int);`
+/// - Without return type: `syscall_hook!(rewinddir, (dirp: *mut libc::DIR));`
+macro_rules! syscall_hook {
+    // Pattern with return type
+    ($syscall:ident, ($($param:ident: $ty:ty),*) -> $ret:ty) => {
+        paste! {
+            pub static [<$syscall:upper _HANDLE>]: std::sync::LazyLock<
+                unsafe extern "C-unwind" fn($($ty),*) -> $ret,
+            > = std::sync::LazyLock::new(|| unsafe {
+                let handle = libc::dlsym(libc::RTLD_NEXT, concat!(stringify!($syscall), "\0").as_ptr() as _);
+                std::mem::transmute::<*mut libc::c_void, unsafe extern "C-unwind" fn($($ty),*) -> $ret>(handle)
+            });
+
+            unsafe extern "C" {
+                fn [<$syscall _from_fs>]($($param: $ty),*) -> $ret;
+            }
+
+            #[unsafe(no_mangle)]
+            unsafe extern "C-unwind" fn $syscall($($param: $ty),*) -> $ret {
+                unsafe { [<$syscall _from_fs>]($($param),*) }
+            }
+        }
+    };
+
+    // Pattern without return type (void)
+    ($syscall:ident, ($($param:ident: $ty:ty),*)) => {
+        paste! {
+            pub static [<$syscall:upper _HANDLE>]: std::sync::LazyLock<
+                unsafe extern "C-unwind" fn($($ty),*),
+            > = std::sync::LazyLock::new(|| unsafe {
+                let handle = libc::dlsym(libc::RTLD_NEXT, concat!(stringify!($syscall), "\0").as_ptr() as _);
+                std::mem::transmute::<*mut libc::c_void, unsafe extern "C-unwind" fn($($ty),*)>(handle)
+            });
+
+            unsafe extern "C" {
+                fn [<$syscall _from_fs>]($($param: $ty),*);
+            }
+
+            #[unsafe(no_mangle)]
+            unsafe extern "C-unwind" fn $syscall($($param: $ty),*) {
+                unsafe { [<$syscall _from_fs>]($($param),*) }
+            }
+        }
+    };
 }
 
-// pthread_create
-pub static PTHREAD_CREATE_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(
-        *mut libc::pthread_t,
-        *const libc::pthread_attr_t,
-        *const unsafe extern "C-unwind" fn(*mut libc::c_void) -> *mut libc::c_void,
-        *const libc::c_void,
-    ) -> libc::c_int,
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"pthread_create\0".as_ptr() as _);
-    std::mem::transmute::<
-        *mut libc::c_void,
-        unsafe extern "C-unwind" fn(
-            *mut libc::pthread_t,
-            *const libc::pthread_attr_t,
-            *const unsafe extern "C-unwind" fn(*mut libc::c_void) -> *mut libc::c_void,
-            *const libc::c_void,
-        ) -> libc::c_int,
-    >(handle)
-});
-
-#[no_mangle]
-unsafe extern "C-unwind" fn pthread_create(
-    thread: *mut libc::pthread_t,
-    attr: *const libc::pthread_attr_t,
-    start_routine: *const unsafe extern "C-unwind" fn(*mut libc::c_void) -> *mut libc::c_void,
-    arg: *const libc::c_void,
-) -> libc::c_int {
-    PTHREAD_CREATE_HANDLE(thread, attr, start_routine, arg)
-    // let ret = PTHREAD_CREATE_HANDLE(thread, attr, start_routine, arg);
-    // let binding = std::sync::Arc::clone(THREAD_CONTEXT.get_or_init(initialize_thread_context));
-    // {
-    //     let mut binding = binding.write().expect("THREAD_CONTEXT is posioned");
-    //     let context = binding
-    //         .get(&libc::pthread_self())
-    //         .expect("not found thread id in THREAD_CONTEXT")
-    //         .clone();
-    //     binding.insert(*thread, context);
-    // }
-
-    // ret
-}
-
-extern "C" {
-    fn open_from_fs(
-        path: *const libc::c_char,
-        oflag: libc::c_int,
-        mode: libc::mode_t,
-    ) -> libc::c_int;
-}
-
-// open
-pub static OPEN_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(*const libc::c_char, libc::c_int, libc::mode_t) -> libc::c_int,
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"open\0".as_ptr() as _);
-    std::mem::transmute::<
-        *mut libc::c_void,
-        unsafe extern "C-unwind" fn(*const libc::c_char, libc::c_int, libc::mode_t) -> libc::c_int,
-    >(handle)
-});
-
-// const ALLOW_OPEN_PATTARN1: i32 = libc::O_RDONLY | libc::O_NONBLOCK | libc::O_CLOEXEC;
-// const ALLOW_OPEN_PATTARN2: i32 = libc::O_RDONLY | libc::O_NONBLOCK;
-// const ALLOW_OPEN_PATTARN3: i32 = libc::O_RDONLY | libc::O_CLOEXEC;
-// const ALLOW_OPEN_PATTARN4: i32 = libc::O_RDONLY | libc::MS_NOATIME;
-
-#[no_mangle]
-unsafe extern "C-unwind" fn open(
-    path: *const libc::c_char,
-    oflag: libc::c_int,
-    mode: libc::mode_t,
-) -> libc::c_int {
-    // println!(
-    //     "rust open: path: {:?}, oflag: {}, mode: {}",
-    //     CStr::from_ptr(path),
-    //     oflag,
-    //     mode
-    // );
-    open_from_fs(path, oflag, mode)
-}
-
-// openat
-pub static OPENAT_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(
-        libc::c_int,
-        *const libc::c_char,
-        libc::c_int,
-        libc::mode_t,
-    ) -> libc::c_int,
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"openat\0".as_ptr() as _);
-    std::mem::transmute::<
-        *mut libc::c_void,
-        unsafe extern "C-unwind" fn(
-            libc::c_int,
-            *const libc::c_char,
-            libc::c_int,
-            libc::mode_t,
-        ) -> libc::c_int,
-    >(handle)
-});
-
-// const ALLOW_OPENAT_PATTARN1: i32 = libc::O_RDONLY | libc::O_CLOEXEC | libc::O_DIRECTORY;
-
-extern "C" {
-    fn openat_from_fs(
-        dirfd: libc::c_int,
-        pathname: *const libc::c_char,
-        flags: libc::c_int,
-        mode: libc::mode_t,
-    ) -> libc::c_int;
-}
-
-#[no_mangle]
-unsafe extern "C-unwind" fn openat(
-    dirfd: libc::c_int,
-    pathname: *const libc::c_char,
-    flags: libc::c_int,
-    mode: libc::mode_t,
-) -> libc::c_int {
-    // println!(
-    //     "rust openat: path: {:?}, fd: {}, flags: {}, mode: {}",
-    //     CStr::from_ptr(pathname),
-    //     dirfd,
-    //     flags,
-    //     mode
-    // );
-    openat_from_fs(dirfd, pathname, flags, mode)
-}
-
-// mmap
-pub static MMAP_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(
-        addr: *mut libc::c_void,
-        length: libc::size_t,
-        prot: libc::c_int,
-        flags: libc::c_int,
-        fd: libc::c_int,
-        offset: libc::off_t,
-    ) -> *mut libc::c_void,
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"mmap\0".as_ptr() as _);
-    std::mem::transmute::<
-        *mut libc::c_void,
-        unsafe extern "C-unwind" fn(
-            addr: *mut libc::c_void,
-            length: libc::size_t,
-            prot: libc::c_int,
-            flags: libc::c_int,
-            fd: libc::c_int,
-            offset: libc::off_t,
-        ) -> *mut libc::c_void,
-    >(handle)
-});
-
-extern "C" {
-    fn mmap_from_fs(
-        addr: *mut libc::c_void,
-        length: libc::size_t,
-        prot: libc::c_int,
-        flags: libc::c_int,
-        fd: libc::c_int,
-        offset: libc::off_t,
-    ) -> *mut libc::c_void;
-}
-
-#[no_mangle]
-unsafe extern "C-unwind" fn mmap(
-    addr: *mut libc::c_void,
-    length: libc::size_t,
-    prot: libc::c_int,
-    flags: libc::c_int,
-    fd: libc::c_int,
-    offset: libc::off_t,
-) -> *mut libc::c_void {
-    mmap_from_fs(addr, length, prot, flags, fd, offset)
-}
-
-// read
-pub static READ_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(
-        fd: libc::c_int,
-        buf: *mut libc::c_void,
-        count: libc::size_t,
-    ) -> libc::ssize_t,
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"read\0".as_ptr() as _);
-    std::mem::transmute::<
-        *mut libc::c_void,
-        unsafe extern "C-unwind" fn(
-            fd: libc::c_int,
-            buf: *mut libc::c_void,
-            count: libc::size_t,
-        ) -> libc::ssize_t,
-    >(handle)
-});
-
-extern "C" {
-    fn read_from_fs(fd: libc::c_int, buf: *mut libc::c_void, count: libc::size_t) -> libc::ssize_t;
-}
-
-#[no_mangle]
-unsafe extern "C-unwind" fn read(
-    fd: libc::c_int,
-    buf: *mut libc::c_void,
-    count: libc::size_t,
-) -> libc::ssize_t {
-    // println!("rust read: fd: {}, count: {}", fd, count);
-    read_from_fs(fd, buf, count)
-}
-
-// readv
-// pub static READV_HANDLE: std::sync::LazyLock<
-//     unsafe extern "C-unwind" fn(libc::c_int, *const libc::iovec, libc::c_int) -> libc::ssize_t,
-// > = std::sync::LazyLock::new(|| unsafe {
-//     let handle = libc::dlsym(libc::RTLD_NEXT, b"readv\0".as_ptr() as _);
-//     std::mem::transmute::<
-//         *mut libc::c_void,
-//         unsafe extern "C-unwind" fn(libc::c_int, *const libc::iovec, libc::c_int) -> libc::ssize_t,
-//     >(handle)
-// });
-
-// #[no_mangle]
-// unsafe extern "C-unwind" fn readv(
-//     fd: libc::c_int,
-//     iov: *const libc::iovec,
-//     iovcnt: libc::c_int,
-// ) -> libc::ssize_t {
-//     println!("rust readv");
-
-//     READV_HANDLE(fd, iov, iovcnt)
-// }
-
-//pread
-// pub static PREAD_HANDLE: std::sync::LazyLock<
-//     unsafe extern "C-unwind" fn(
-//         libc::c_int,
-//         *mut libc::c_void,
-//         libc::size_t,
-//         libc::off_t,
-//     ) -> libc::ssize_t,
-// > = std::sync::LazyLock::new(|| unsafe {
-//     let handle = libc::dlsym(libc::RTLD_NEXT, b"pread\0".as_ptr() as _);
-//     std::mem::transmute::<
-//         *mut libc::c_void,
-//         unsafe extern "C-unwind" fn(
-//             libc::c_int,
-//             *mut libc::c_void,
-//             libc::size_t,
-//             libc::off_t,
-//         ) -> libc::ssize_t,
-//     >(handle)
-// });
-
-// #[no_mangle]
-// pub unsafe extern "C-unwind" fn pread(
-//     fd: libc::c_int,
-//     buf: *mut libc::c_void,
-//     count: libc::size_t,
-//     offset: libc::off_t,
-// ) -> libc::ssize_t {
-//     println!("rust pread");
-
-//     PREAD_HANDLE(fd, buf, count, offset)
-// }
-
-//lseek
-// pub static LSEEK_HANDLE: std::sync::LazyLock<
-//     unsafe extern "C-unwind" fn(libc::c_int, libc::off_t, libc::c_int) -> libc::off_t,
-// > = std::sync::LazyLock::new(|| unsafe {
-//     let handle = libc::dlsym(libc::RTLD_NEXT, b"lseek\0".as_ptr() as _);
-//     std::mem::transmute::<
-//         *mut libc::c_void,
-//         unsafe extern "C-unwind" fn(libc::c_int, libc::off_t, libc::c_int) -> libc::off_t,
-//     >(handle)
-// });
-
-// #[no_mangle]
-// unsafe extern "C-unwind" fn lseek(
-//     fildes: libc::c_int,
-//     offset: libc::off_t,
-//     whence: libc::c_int,
-// ) -> libc::off_t {
-//     LSEEK_HANDLE(fildes, offset, whence)
-// }
-
-//stat
-pub static STAT_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(*const libc::c_char, *mut libc::stat) -> libc::c_int,
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"stat\0".as_ptr() as _);
-    std::mem::transmute::<
-        *mut libc::c_void,
-        unsafe extern "C-unwind" fn(*const libc::c_char, *mut libc::stat) -> libc::c_int,
-    >(handle)
-});
-
-extern "C" {
-    fn stat_from_fs(path: *const libc::c_char, buf: *mut libc::stat) -> libc::c_int;
-}
-
-#[no_mangle]
-unsafe extern "C-unwind" fn stat(path: *const libc::c_char, buf: *mut libc::stat) -> libc::c_int {
-    stat_from_fs(path, buf)
-}
-
-//fstat
-pub static FSTAT_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(fildes: libc::c_int, buf: *mut libc::stat) -> libc::c_int,
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"fstat\0".as_ptr() as _);
-    std::mem::transmute::<
-        *mut libc::c_void,
-        unsafe extern "C-unwind" fn(fildes: libc::c_int, buf: *mut libc::stat) -> libc::c_int,
-    >(handle)
-});
-
-extern "C" {
-    fn fstat_from_fs(fildes: libc::c_int, buf: *mut libc::stat) -> libc::c_int;
-}
-
-#[no_mangle]
-unsafe extern "C-unwind" fn fstat(fildes: libc::c_int, buf: *mut libc::stat) -> libc::c_int {
-    fstat_from_fs(fildes, buf)
-}
-
-//fstatat
-pub static FSTATAT_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(
-        dirfd: libc::c_int,
-        pathname: *const libc::c_char,
-        buf: *mut libc::stat,
-        flags: libc::c_int,
-    ) -> libc::c_int,
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"fstatat\0".as_ptr() as _);
-    std::mem::transmute::<
-        *mut libc::c_void,
-        unsafe extern "C-unwind" fn(
-            dirfd: libc::c_int,
-            pathname: *const libc::c_char,
-            buf: *mut libc::stat,
-            flags: libc::c_int,
-        ) -> libc::c_int,
-    >(handle)
-});
-
-extern "C" {
-    fn fstatat_from_fs(
-        dirfd: libc::c_int,
-        pathname: *const libc::c_char,
-        buf: *mut libc::stat,
-        flags: libc::c_int,
-    ) -> libc::c_int;
-}
-
-#[no_mangle]
-unsafe extern "C-unwind" fn fstatat(
-    dirfd: libc::c_int,
-    pathname: *const libc::c_char,
-    buf: *mut libc::stat,
-    flags: libc::c_int,
-) -> libc::c_int {
-    fstatat_from_fs(dirfd, pathname, buf, flags)
-}
-
-//lstat
-pub static LSTAT_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(path: *const libc::c_char, buf: *mut libc::stat) -> libc::c_int,
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"lstat\0".as_ptr() as _);
-    std::mem::transmute::<
-        *mut libc::c_void,
-        unsafe extern "C-unwind" fn(path: *const libc::c_char, buf: *mut libc::stat) -> libc::c_int,
-    >(handle)
-});
-
-extern "C" {
-    fn lstat_from_fs(path: *const libc::c_char, buf: *mut libc::stat) -> libc::c_int;
-}
-
-#[no_mangle]
-unsafe extern "C-unwind" fn lstat(path: *const libc::c_char, buf: *mut libc::stat) -> libc::c_int {
-    lstat_from_fs(path, buf)
-}
-
-extern "C" {
-    fn close_from_fs(fd: libc::c_int) -> libc::c_int;
-}
-
-//close
-pub static CLOSE_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(libc::c_int) -> libc::c_int,
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"close\0".as_ptr() as _);
-    std::mem::transmute::<*mut libc::c_void, unsafe extern "C-unwind" fn(libc::c_int) -> libc::c_int>(
-        handle,
-    )
-});
-
-#[no_mangle]
-unsafe extern "C-unwind" fn close(d: libc::c_int) -> libc::c_int {
-    close_from_fs(d)
-}
-
-//getcwd
-pub static GETCWD_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(
-        buf: *mut libc::c_char,
-        length: libc::size_t,
-    ) -> *const libc::c_char,
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"getcwd\0".as_ptr() as _);
-    std::mem::transmute::<
-        *mut libc::c_void,
-        unsafe extern "C-unwind" fn(
-            buf: *mut libc::c_char,
-            length: libc::size_t,
-        ) -> *const libc::c_char,
-    >(handle)
-});
-
-extern "C" {
-    fn getcwd_from_fs(buf: *mut libc::c_char, length: libc::size_t) -> *const libc::c_char;
-}
-
-#[no_mangle]
-unsafe extern "C-unwind" fn getcwd(
-    buf: *mut libc::c_char,
-    length: libc::size_t,
-) -> *const libc::c_char {
-    // println!("rust getcwd len: {}, buf: {:?}", length, buf);
-
-    getcwd_from_fs(buf, length)
-}
-
-//getwd
-// pub static GETWD_HANDLE: std::sync::LazyLock<
-//     unsafe extern "C-unwind" fn(path_name: *const libc::c_char) -> *const libc::c_char,
-// > = std::sync::LazyLock::new(|| unsafe {
-//     let handle = libc::dlsym(libc::RTLD_NEXT, b"getwd\0".as_ptr() as _);
-//     std::mem::transmute::<
-//         *mut libc::c_void,
-//         unsafe extern "C-unwind" fn(path_name: *const libc::c_char) -> *const libc::c_char,
-//     >(handle)
-// });
-
-// #[no_mangle]
-// unsafe extern "C-unwind" fn getwd(path_name: *const libc::c_char) -> *const libc::c_char {
-//     println!("rust getwd: {:?}", CStr::from_ptr(path_name));
-
-//     GETWD_HANDLE(path_name)
-// }
-
-//execv
-// pub static EXECV_HANDLE: std::sync::LazyLock<
-//     unsafe extern "C-unwind" fn(
-//         prog: *const libc::c_char,
-//         argv: *const *const libc::c_char,
-//     ) -> libc::c_int,
-// > = std::sync::LazyLock::new(|| unsafe {
-//     let handle = libc::dlsym(libc::RTLD_NEXT, b"execv\0".as_ptr() as _);
-//     std::mem::transmute::<
-//         *mut libc::c_void,
-//         unsafe extern "C-unwind" fn(
-//             prog: *const libc::c_char,
-//             argv: *const *const libc::c_char,
-//         ) -> libc::c_int,
-//     >(handle)
-// });
-
-// #[no_mangle]
-// unsafe extern "C-unwind" fn execv(
-//     prog: *const libc::c_char,
-//     argv: *const *const libc::c_char,
-// ) -> libc::c_int {
-//     println!("rust execv");
-
-//     EXECV_HANDLE(prog, argv)
-// }
-
-//access
-// pub static ACCSESS_HANDLE: std::sync::LazyLock<
-//     unsafe extern "C-unwind" fn(path: *const libc::c_char, amode: libc::c_int) -> libc::c_int,
-// > = std::sync::LazyLock::new(|| unsafe {
-//     let handle = libc::dlsym(libc::RTLD_NEXT, b"access\0".as_ptr() as _);
-//     std::mem::transmute::<
-//         *mut libc::c_void,
-//         unsafe extern "C-unwind" fn(path: *const libc::c_char, amode: libc::c_int) -> libc::c_int,
-//     >(handle)
-// });
-
-// #[no_mangle]
-// unsafe extern "C-unwind" fn access(path: *const libc::c_char, amode: libc::c_int) -> libc::c_int {
-//     println!("rust access");
-
-//     ACCSESS_HANDLE(path, amode)
-// }
-
-//opendir
-pub static OPENDIR_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(dirname: *const libc::c_char) -> *mut libc::DIR,
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"opendir\0".as_ptr() as _);
-    std::mem::transmute::<
-        *mut libc::c_void,
-        unsafe extern "C-unwind" fn(dirname: *const libc::c_char) -> *mut libc::DIR,
-    >(handle)
-});
-
-extern "C" {
-    fn opendir_from_fs(dirname: *const libc::c_char) -> *mut libc::DIR;
-}
-
-#[no_mangle]
-unsafe extern "C-unwind" fn opendir(dirname: *const libc::c_char) -> *mut libc::DIR {
-    opendir_from_fs(dirname)
-}
-
-//fdopendir
-pub static FDOPENDIR_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(fd: libc::c_int) -> *mut libc::DIR,
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"fdopendir\0".as_ptr() as _);
-    std::mem::transmute::<
-        *mut libc::c_void,
-        unsafe extern "C-unwind" fn(fd: libc::c_int) -> *mut libc::DIR,
-    >(handle)
-});
-
-extern "C" {
-    fn fdopendir_from_fs(fd: libc::c_int) -> *mut libc::DIR;
-}
-
-#[no_mangle]
-unsafe extern "C-unwind" fn fdopendir(fd: libc::c_int) -> *mut libc::DIR {
-    // println!("rust fdopendir: {:?}", fd);
-
-    fdopendir_from_fs(fd)
-}
-
-//readdir
-pub static READDIR_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(dirp: *mut libc::DIR) -> *mut libc::dirent,
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"readdir\0".as_ptr() as _);
-    std::mem::transmute::<
-        *mut libc::c_void,
-        unsafe extern "C-unwind" fn(dirp: *mut libc::DIR) -> *mut libc::dirent,
-    >(handle)
-});
-
-extern "C" {
-    fn readdir_from_fs(dirp: *mut libc::DIR) -> *mut libc::dirent;
-}
-
-#[no_mangle]
-unsafe extern "C-unwind" fn readdir(dirp: *mut libc::DIR) -> *mut libc::dirent {
-    readdir_from_fs(dirp)
-}
-
-//telledir
-// pub static TELLDIR_HANDLE: std::sync::LazyLock<
-//     unsafe extern "C-unwind" fn(dirp: *mut libc::DIR) -> libc::c_long,
-// > = std::sync::LazyLock::new(|| unsafe {
-//     let handle = libc::dlsym(libc::RTLD_NEXT, b"telldir\0".as_ptr() as _);
-//     std::mem::transmute::<
-//         *mut libc::c_void,
-//         unsafe extern "C-unwind" fn(dirp: *mut libc::DIR) -> libc::c_long,
-//     >(handle)
-// });
-
-// #[no_mangle]
-// unsafe extern "C-unwind" fn telldir(dirp: *mut libc::DIR) -> libc::c_long {
-//     println!("rust telldir: {:?}", dirp);
-
-//     TELLDIR_HANDLE(dirp)
-// }
-
-//rewinddir
-pub static REWINDDIR_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(dirp: *mut libc::DIR),
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"rewinddir\0".as_ptr() as _);
-    std::mem::transmute::<*mut libc::c_void, unsafe extern "C-unwind" fn(dirp: *mut libc::DIR)>(
-        handle,
-    )
-});
-
-extern "C" {
-    fn rewinddir_from_fs(dirp: *mut libc::DIR);
-}
-
-#[no_mangle]
-unsafe extern "C-unwind" fn rewinddir(dirp: *mut libc::DIR) {
-    // println!("rust rewinddir: {:?}", dirp);
-
-    rewinddir_from_fs(dirp)
-}
-
-//seekdir
-// pub static SEEKDIR_HANDLE: std::sync::LazyLock<
-//     unsafe extern "C-unwind" fn(dirp: *mut libc::DIR, loc: libc::c_long),
-// > = std::sync::LazyLock::new(|| unsafe {
-//     let handle = libc::dlsym(libc::RTLD_NEXT, b"seekdir\0".as_ptr() as _);
-//     std::mem::transmute::<
-//         *mut libc::c_void,
-//         unsafe extern "C-unwind" fn(dirp: *mut libc::DIR, loc: libc::c_long),
-//     >(handle)
-// });
-
-// #[no_mangle]
-// unsafe extern "C-unwind" fn seekdir(dirp: *mut libc::DIR, loc: libc::c_long) {
-//     println!("rust seekdir: {:?}", dirp);
-
-//     SEEKDIR_HANDLE(dirp, loc)
-// }
-
-//dirfd
-// pub static DIRFD_HANDLE: std::sync::LazyLock<
-//     unsafe extern "C-unwind" fn(dirp: *mut libc::DIR) -> libc::c_int,
-// > = std::sync::LazyLock::new(|| unsafe {
-//     let handle = libc::dlsym(libc::RTLD_NEXT, b"dirfd\0".as_ptr() as _);
-//     std::mem::transmute::<
-//         *mut libc::c_void,
-//         unsafe extern "C-unwind" fn(dirp: *mut libc::DIR) -> libc::c_int,
-//     >(handle)
-// });
-
-// #[no_mangle]
-// unsafe extern "C-unwind" fn dirfd(dirp: *mut libc::DIR) -> libc::c_int {
-//     println!("rust dirfd: {:?}", dirp);
-
-//     DIRFD_HANDLE(dirp)
-// }
-
-//mkdir
-pub static MKDIR_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(path: *const libc::c_char, mode: libc::mode_t) -> libc::c_int,
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"mkdir\0".as_ptr() as _);
-    std::mem::transmute::<
-        *mut libc::c_void,
-        unsafe extern "C-unwind" fn(path: *const libc::c_char, mode: libc::mode_t) -> libc::c_int,
-    >(handle)
-});
-
-extern "C" {
-    fn mkdir_from_fs(path: *const libc::c_char, mode: libc::mode_t) -> libc::c_int;
-}
-
-#[no_mangle]
-unsafe extern "C-unwind" fn mkdir(path: *const libc::c_char, mode: libc::mode_t) -> libc::c_int {
-    // println!("rust mkdir: {:?}", CStr::from_ptr(path));
-
-    mkdir_from_fs(path, mode)
-}
-
-//closedir
-pub static CLOSEDIR_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(dirp: *mut libc::DIR) -> libc::c_int,
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"closedir\0".as_ptr() as _);
-    std::mem::transmute::<
-        *mut libc::c_void,
-        unsafe extern "C-unwind" fn(dirp: *mut libc::DIR) -> libc::c_int,
-    >(handle)
-});
-
-extern "C" {
-    fn closedir_from_fs(dirp: *mut libc::DIR) -> libc::c_int;
-}
-
-#[no_mangle]
-unsafe extern "C-unwind" fn closedir(dirp: *mut libc::DIR) -> libc::c_int {
-    // println!("rust closedir: {:?}", dirp);
-
-    closedir_from_fs(dirp)
-}
-
-//chdir
-pub static CHDIR_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(path: *const libc::c_char) -> libc::c_int,
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"chdir\0".as_ptr() as _);
-    std::mem::transmute::<
-        *mut libc::c_void,
-        unsafe extern "C-unwind" fn(path: *const libc::c_char) -> libc::c_int,
-    >(handle)
-});
-
-extern "C" {
-    fn chdir_from_fs(path: *const libc::c_char) -> libc::c_int;
-}
-
-#[no_mangle]
-unsafe extern "C-unwind" fn chdir(path: *const libc::c_char) -> libc::c_int {
-    // println!("rust chdir: {:?}", CStr::from_ptr(path));
-
-    chdir_from_fs(path)
-}
-
-//readlink
-// pub static READLINK_HANDLE: std::sync::LazyLock<
-//     unsafe extern "C-unwind" fn(
-//         path: *const libc::c_char,
-//         buf: *mut libc::c_char,
-//         bufsz: libc::size_t,
-//     ) -> libc::ssize_t,
-// > = std::sync::LazyLock::new(|| unsafe {
-//     let handle = libc::dlsym(libc::RTLD_NEXT, b"readlink\0".as_ptr() as _);
-//     std::mem::transmute::<
-//         *mut libc::c_void,
-//         unsafe extern "C-unwind" fn(
-//             path: *const libc::c_char,
-//             buf: *mut libc::c_char,
-//             bufsz: libc::size_t,
-//         ) -> libc::ssize_t,
-//     >(handle)
-// });
-
-// #[no_mangle]
-// unsafe extern "C-unwind" fn readlink(
-//     path: *const libc::c_char,
-//     buf: *mut libc::c_char,
-//     bufsz: libc::size_t,
-// ) -> libc::ssize_t {
-//     println!("rust readlink: {:?}", CStr::from_ptr(path));
-
-//     READLINK_HANDLE(path, buf, bufsz)
-// }
-
-//realpath
-pub static REALPATH_HANDLE: std::sync::LazyLock<
-    unsafe extern "C-unwind" fn(
-        path: *const libc::c_char,
-        resolved_path: *mut libc::c_char,
-    ) -> *const libc::c_char,
-> = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"realpath\0".as_ptr() as _);
-    std::mem::transmute::<
-        *mut libc::c_void,
-        unsafe extern "C-unwind" fn(
-            path: *const libc::c_char,
-            resolved_path: *mut libc::c_char,
-        ) -> *const libc::c_char,
-    >(handle)
-});
-
-extern "C" {
-    fn realpath_from_fs(
-        path: *const libc::c_char,
-        resolved_path: *mut libc::c_char,
-    ) -> *const libc::c_char;
-}
-
-#[no_mangle]
-unsafe extern "C-unwind" fn realpath(
-    path: *const libc::c_char,
-    resolved_path: *mut libc::c_char,
-) -> *const libc::c_char {
-    realpath_from_fs(path, resolved_path)
-}
-
-// //dlopen
-// pub static DLOPEN_HANDLE: std::sync::LazyLock<
-//     unsafe extern "C-unwind" fn(
-//         filename: *const libc::c_char,
-//         flag: libc::c_int,
-//     ) -> *mut libc::c_void,
-// > = std::sync::LazyLock::new(|| unsafe {
-//     let handle = libc::dlsym(libc::RTLD_NEXT, b"dlopen\0".as_ptr() as _);
-//     std::mem::transmute::<
-//         *mut libc::c_void,
-//         unsafe extern "C-unwind" fn(
-//             filename: *const libc::c_char,
-//             flag: libc::c_int,
-//         ) -> *mut libc::c_void,
-//     >(handle)
-// });
-
-// #[no_mangle]
-// unsafe extern "C-unwind" fn dlopen(
-//     filename: *const libc::c_char,
-//     flag: libc::c_int,
-// ) -> *mut libc::c_void {
-//     println!("rust dlopen: {:?}", CStr::from_ptr(filename));
-
-//     DLOPEN_HANDLE(filename, flag)
-// }
+// =============================================================================
+// Syscall hooks using the macro
+// =============================================================================
+
+syscall_hook!(open, (path: *const libc::c_char, oflag: libc::c_int, mode: libc::mode_t) -> libc::c_int);
+syscall_hook!(openat, (dirfd: libc::c_int, pathname: *const libc::c_char, flags: libc::c_int, mode: libc::mode_t) -> libc::c_int);
+syscall_hook!(mmap, (addr: *mut libc::c_void, length: libc::size_t, prot: libc::c_int, flags: libc::c_int, fd: libc::c_int, offset: libc::off_t) -> *mut libc::c_void);
+syscall_hook!(read, (fd: libc::c_int, buf: *mut libc::c_void, count: libc::size_t) -> libc::ssize_t);
+syscall_hook!(stat, (path: *const libc::c_char, buf: *mut libc::stat) -> libc::c_int);
+syscall_hook!(fstat, (fildes: libc::c_int, buf: *mut libc::stat) -> libc::c_int);
+syscall_hook!(fstatat, (dirfd: libc::c_int, pathname: *const libc::c_char, buf: *mut libc::stat, flags: libc::c_int) -> libc::c_int);
+syscall_hook!(lstat, (path: *const libc::c_char, buf: *mut libc::stat) -> libc::c_int);
+syscall_hook!(close, (fd: libc::c_int) -> libc::c_int);
+syscall_hook!(getcwd, (buf: *mut libc::c_char, length: libc::size_t) -> *const libc::c_char);
+syscall_hook!(opendir, (dirname: *const libc::c_char) -> *mut libc::DIR);
+syscall_hook!(fdopendir, (fd: libc::c_int) -> *mut libc::DIR);
+syscall_hook!(readdir, (dirp: *mut libc::DIR) -> *mut libc::dirent);
+syscall_hook!(rewinddir, (dirp: *mut libc::DIR));
+syscall_hook!(mkdir, (path: *const libc::c_char, mode: libc::mode_t) -> libc::c_int);
+syscall_hook!(closedir, (dirp: *mut libc::DIR) -> libc::c_int);
+syscall_hook!(chdir, (path: *const libc::c_char) -> libc::c_int);
+syscall_hook!(realpath, (path: *const libc::c_char, resolved_path: *mut libc::c_char) -> *const libc::c_char);
 
 // getattrlist - macOS only
 #[cfg(target_os = "macos")]
+#[allow(non_snake_case)]
 pub static GETATTRLIST_HANDLE: std::sync::LazyLock<
     unsafe extern "C-unwind" fn(
         path: *const libc::c_char,
@@ -812,7 +84,7 @@ pub static GETATTRLIST_HANDLE: std::sync::LazyLock<
         options: libc::c_ulong,
     ) -> libc::c_int,
 > = std::sync::LazyLock::new(|| unsafe {
-    let handle = libc::dlsym(libc::RTLD_NEXT, b"getattrlist\0".as_ptr() as _);
+    let handle = libc::dlsym(libc::RTLD_NEXT, c"getattrlist".as_ptr() as _);
     std::mem::transmute::<
         *mut libc::c_void,
         unsafe extern "C-unwind" fn(
@@ -826,7 +98,8 @@ pub static GETATTRLIST_HANDLE: std::sync::LazyLock<
 });
 
 #[cfg(target_os = "macos")]
-extern "C" {
+unsafe extern "C" {
+    #[allow(non_snake_case)]
     fn getattrlist_from_fs(
         path: *const libc::c_char,
         attrList: *mut libc::c_void,
@@ -837,7 +110,7 @@ extern "C" {
 }
 
 #[cfg(target_os = "macos")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C-unwind" fn getattrlist(
     path: *const libc::c_char,
     attr_list: *mut libc::c_void,
@@ -845,5 +118,5 @@ unsafe extern "C-unwind" fn getattrlist(
     attr_buf_size: libc::size_t,
     options: libc::c_ulong,
 ) -> libc::c_int {
-    getattrlist_from_fs(path, attr_list, attr_buf, attr_buf_size, options)
+    unsafe { getattrlist_from_fs(path, attr_list, attr_buf, attr_buf_size, options) }
 }


### PR DESCRIPTION
## Summary

- Upgrade all crates to Rust 2024 edition
- Replace `static mut` with thread-safe alternatives (`RwLock`, `OnceLock`, `LazyLock`)
- Add explicit `unsafe` blocks in `unsafe fn` bodies (Rust 2024 requirement)
- Use `#[unsafe(no_mangle)]` and `unsafe extern "C"` (Rust 2024 syntax)
- Refactor kompo_wrap with macros to reduce boilerplate (~850 lines → ~160 lines)
- Mark raw pointer functions in util.rs as `unsafe fn` with safety documentation
- Replace fxhash with rustc-hash (actively maintained)

## Test plan

- [x] `cargo build --release` passes
- [x] `cargo test -p kompo_storage -p kompo_fs` passes (62 tests)
- [x] `cargo clippy` passes (warnings only, no errors)

🤖 Generated with [Claude Code](https://claude.ai/code)