### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.1] - 2026-01-23
+
+### Changed
+- Upgrade to Rust 2024 edition with thread-safe improvements [#13](https://github.com/ahogappa/kompo-vfs/pull/13)
+- Refactor kompo_wrap to use thread-safe patterns
+- Make convert_byte signature consistent across platforms
+
+## [0.4.0] - 2026-01-21
+
+### Added
+- Add `kompo_fs_set_entrypoint_dir` function for setting entrypoint directory [#12](https://github.com/ahogappa/kompo-vfs/pull/12)
+- Add unit tests for `kompo_fs_set_entrypoint_dir` function
+
+## [0.3.0] - 2026-01-20
+
+### Added
+- Add `getattrlist` syscall support for macOS [#10](https://github.com/ahogappa/kompo-vfs/pull/10)
+- Add comprehensive unit tests for kompo_storage and kompo_fs [#8](https://github.com/ahogappa/kompo-vfs/pull/8)
+- Add kompo_fs tests to CI pipeline
+
+### Fixed
+- Fix macOS build issues [#9](https://github.com/ahogappa/kompo-vfs/pull/9)
+
+## [0.2.0] - 2025-04-25
+
+### Changed
+- Refactor codebase [#6](https://github.com/ahogappa/kompo-vfs/pull/6)
+
+### Fixed
+- Fix formula file [#5](https://github.com/ahogappa/kompo-vfs/pull/5)
+
+### Removed
+- Delete START_FILE_PATH static variable [#4](https://github.com/ahogappa/kompo-vfs/pull/4)
+
+## [0.1.0] - 2025-04-08
+
+### Added
+- Initial release with virtual filesystem implementation
+- Use dlsym with RTLD_NEXT for syscall interception [#2](https://github.com/ahogappa/kompo-vfs/pull/2)
+- Support for file operations: open, close, read, pread, realpath
+- Support for directory operations: opendir, readdir, closedir, fdopendir
+- Support for stat operations: stat, lstat, fstat, fstatat
+- Ruby FFI bindings for kompo gem integration

--- a/Formula/kompo-vfs.rb
+++ b/Formula/kompo-vfs.rb
@@ -3,7 +3,7 @@ class KompoVfs < Formula
   homepage "https://github.com/ahogappa/kompo-vfs"
   url "https://github.com/ahogappa/kompo-vfs.git", using: :git, branch: "main"
   head "https://github.com/ahogappa/kompo-vfs.git", branch: "main"
-  version "0.4.0"
+  version "0.4.1"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Summary
- Update Formula version from 0.4.0 to 0.4.1
- Add CHANGELOG.md with full version history

## Changes in v0.4.1
- Upgrade to Rust 2024 edition with thread-safe improvements
- Refactor kompo_wrap to use thread-safe patterns
- Make convert_byte signature consistent across platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)