### PR TITLE
feat: enable PIC for x86_64 Linux and add version output

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "relocation-model=pic", "-C", "panic=abort"]
+rustflags = ["-C", "relocation-model=pic"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "relocation-model=pic"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "relocation-model=pic"]
+rustflags = ["-C", "relocation-model=pic", "-C", "panic=abort"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "kompo_fs"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "errno",
  "kompo_fs_test_data",

--- a/kompo_fs/Cargo.toml
+++ b/kompo_fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kompo_fs"
-version = "0.1.0"
+version = "0.5.0"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/kompo_fs/build.rs
+++ b/kompo_fs/build.rs
@@ -1,0 +1,22 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    // Get the target directory from OUT_DIR
+    // OUT_DIR is typically target/release/build/kompo_fs-xxx/out
+    // So target/release is 3 levels up
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let target_dir = Path::new(&out_dir)
+        .ancestors()
+        .nth(3)
+        .expect("Failed to find target directory");
+
+    // Write KOMPO_VFS_VERSION file to target/release (or target/debug)
+    let version = env!("CARGO_PKG_VERSION");
+    fs::write(target_dir.join("KOMPO_VFS_VERSION"), version)
+        .expect("Failed to write KOMPO_VFS_VERSION file");
+
+    // Rerun if Cargo.toml changes
+    println!("cargo:rerun-if-changed=Cargo.toml");
+}


### PR DESCRIPTION
## Summary
- Enable Position Independent Code (PIC) for x86_64-unknown-linux-gnu target to support PIE (Position Independent Executable) binaries
- Add `panic=abort` flag for x86_64 Linux to reduce binary size
- Add build.rs to output KOMPO_VFS_VERSION file during build for version tracking
- Bump kompo_fs version to 0.5.0

## Test plan
- [ ] Build on x86_64 Linux and verify PIC is working correctly
- [ ] Verify KOMPO_VFS_VERSION file is created in target directory
- [ ] Test with kompo gem to ensure VFS works with PIE binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)