### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-01-24
+
+### Added
+- Enable PIC (Position Independent Code) for x86_64 Linux to support PIE binaries [#15](https://github.com/ahogappa/kompo-vfs/pull/15)
+- Add panic=abort flag and version output for x86_64 Linux [#15](https://github.com/ahogappa/kompo-vfs/pull/15)
+
+### Fixed
+- Remove panic=abort from config.toml to fix test builds [#15](https://github.com/ahogappa/kompo-vfs/pull/15)
+
 ## [0.4.1] - 2026-01-23
 
 ### Changed

--- a/Formula/kompo-vfs.rb
+++ b/Formula/kompo-vfs.rb
@@ -3,7 +3,7 @@ class KompoVfs < Formula
   homepage "https://github.com/ahogappa/kompo-vfs"
   url "https://github.com/ahogappa/kompo-vfs.git", using: :git, branch: "main"
   head "https://github.com/ahogappa/kompo-vfs.git", branch: "main"
-  version "0.4.1"
+  version "0.5.0"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Summary
- Bump version to 0.5.0
- Update CHANGELOG.md for v0.5.0 release

### Changes in this release
- Enable PIC (Position Independent Code) for x86_64 Linux to support PIE binaries
- Add panic=abort flag and version output for x86_64 Linux
- Fix: Remove panic=abort from config.toml to fix test builds

## Test plan
- [x] All tests pass (`cargo test -p kompo_storage -p kompo_fs`)
- [x] Clippy lint passes (`cargo clippy`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)