### PR TITLE
feat: implement internal RwLock for fd_map in Fs struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,58 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -23,6 +71,93 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "criterion"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d883447757bb0ee46f233e9dc22eb84d93a9508c9b868687b274fc431d886bf"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed943f81ea2faa8dcecbbfa50164acf95d555afec96a27871663b300e387b2e4"
+dependencies = [
+ "cast",
+ "itertools",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -48,6 +183,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "either"
@@ -117,6 +258,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kompo_fs"
 version = "0.5.1"
 dependencies = [
@@ -142,6 +319,7 @@ dependencies = [
 name = "kompo_storage"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "libc",
  "rustc-hash",
  "trie-rs",
@@ -186,10 +364,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "parking_lot"
@@ -231,6 +440,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -280,10 +517,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scc"
@@ -305,6 +586,49 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
 
 [[package]]
 name = "serial_test"
@@ -362,6 +686,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "trie-rs"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +711,102 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,3 +820,29 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71ddd76bcebeed25db614f82bf31a9f4222d3fbba300e6fb6c00afa26cbd4d9d"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8187381b52e32220d50b255276aa16a084ec0a9017a0ca2152a1f55c539758d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"

--- a/kompo_fs/src/lib.rs
+++ b/kompo_fs/src/lib.rs
@@ -6,7 +6,7 @@ use std::ops::Range;
 use std::path::Path;
 use trie_rs::map::TrieBuilder;
 
-static TRIE: std::sync::OnceLock<std::sync::Arc<std::sync::Mutex<kompo_storage::Fs>>> =
+static TRIE: std::sync::OnceLock<std::sync::Arc<kompo_storage::Fs>> =
     std::sync::OnceLock::new();
 
 pub static WORKING_DIR: std::sync::RwLock<Option<std::ffi::OsString>> =
@@ -57,8 +57,8 @@ unsafe extern "C" {
     fn rb_yield(v: VALUE) -> VALUE;
 }
 
-fn initialize_trie() -> std::sync::Arc<std::sync::Mutex<kompo_storage::Fs<'static>>> {
-    std::sync::Arc::new(std::sync::Mutex::new(initialize_fs()))
+fn initialize_trie() -> std::sync::Arc<kompo_storage::Fs<'static>> {
+    std::sync::Arc::new(initialize_fs())
 }
 
 unsafe extern "C" fn context_func(_: VALUE, _: VALUE) -> VALUE {

--- a/kompo_fs/src/lib.rs
+++ b/kompo_fs/src/lib.rs
@@ -6,8 +6,7 @@ use std::ops::Range;
 use std::path::Path;
 use trie_rs::map::TrieBuilder;
 
-static TRIE: std::sync::OnceLock<std::sync::Arc<kompo_storage::Fs>> =
-    std::sync::OnceLock::new();
+static TRIE: std::sync::OnceLock<std::sync::Arc<kompo_storage::Fs>> = std::sync::OnceLock::new();
 
 pub static WORKING_DIR: std::sync::RwLock<Option<std::ffi::OsString>> =
     std::sync::RwLock::new(None);

--- a/kompo_fs/src/util.rs
+++ b/kompo_fs/src/util.rs
@@ -95,11 +95,7 @@ pub fn is_fd_exists_in_kompo(fd: i32) -> bool {
     }
 
     let trie = std::sync::Arc::clone(TRIE.get().unwrap());
-    {
-        let trie = trie.lock().unwrap();
-
-        trie.is_fd_exists(fd)
-    }
+    trie.is_fd_exists(fd)
 }
 
 /// # Safety
@@ -112,11 +108,7 @@ pub unsafe fn is_dir_exists_in_kompo(dir: *mut libc::DIR) -> bool {
     let dir = unsafe { Box::from_raw(dir as *mut kompo_storage::FsDir) };
 
     let trie = std::sync::Arc::clone(TRIE.get().unwrap());
-    let bool = {
-        let trie = trie.lock().unwrap();
-
-        trie.is_dir_exists(&dir)
-    };
+    let bool = trie.is_dir_exists(&dir);
 
     let _ = Box::into_raw(dir);
     bool

--- a/kompo_storage/Cargo.toml
+++ b/kompo_storage/Cargo.toml
@@ -7,3 +7,10 @@ edition = "2024"
 libc = "0.2.169"
 trie-rs = "0.4.2"
 rustc-hash = "2"
+
+[dev-dependencies]
+criterion = { version = "0.8.1", features = ["html_reports"] }
+
+[[bench]]
+name = "fs_bench"
+harness = false

--- a/kompo_storage/benches/fs_bench.rs
+++ b/kompo_storage/benches/fs_bench.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use kompo_storage::Fs;
 use std::ffi::OsStr;
 use std::hint::black_box;
@@ -19,7 +19,15 @@ fn create_rails_app_fs() -> Fs<'static> {
     let mut builder: TrieBuilder<&OsStr, &[u8]> = TrieBuilder::new();
 
     // App directory structure (typical Rails app: ~200 files)
-    let app_dirs = ["models", "controllers", "views", "helpers", "jobs", "mailers", "channels"];
+    let app_dirs = [
+        "models",
+        "controllers",
+        "views",
+        "helpers",
+        "jobs",
+        "mailers",
+        "channels",
+    ];
     for dir in app_dirs {
         for i in 0..30 {
             let file = format!("{}{}.rb", dir.trim_end_matches('s'), i);
@@ -166,7 +174,8 @@ fn create_rails_app_fs() -> Fs<'static> {
                 for i in 0..20 {
                     let file = format!("{}{}.rb", subdir, i);
                     let file_leaked: &'static str = Box::leak(file.into_boxed_str());
-                    let subdir_leaked: &'static str = Box::leak(subdir.to_string().into_boxed_str());
+                    let subdir_leaked: &'static str =
+                        Box::leak(subdir.to_string().into_boxed_str());
                     let path: Vec<&OsStr> = vec![
                         OsStr::new("vendor"),
                         OsStr::new("bundle"),
@@ -631,13 +640,26 @@ fn bench_concurrent_stat(c: &mut Criterion) {
             |b, &num_threads| {
                 let fs = Arc::new(Mutex::new(create_rails_app_fs()));
                 let paths: Vec<Vec<&'static OsStr>> = vec![
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb")],
-                    vec![OsStr::new("app"), OsStr::new("controllers"), OsStr::new("controller0.rb")],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model0.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("controllers"),
+                        OsStr::new("controller0.rb"),
+                    ],
                     vec![OsStr::new("config"), OsStr::new("routes.rb")],
                     vec![
-                        OsStr::new("vendor"), OsStr::new("bundle"), OsStr::new("ruby"),
-                        OsStr::new("3.2.0"), OsStr::new("gems"), OsStr::new("rails"),
-                        OsStr::new("lib"), OsStr::new("rails0.rb"),
+                        OsStr::new("vendor"),
+                        OsStr::new("bundle"),
+                        OsStr::new("ruby"),
+                        OsStr::new("3.2.0"),
+                        OsStr::new("gems"),
+                        OsStr::new("rails"),
+                        OsStr::new("lib"),
+                        OsStr::new("rails0.rb"),
                     ],
                 ];
                 let paths = Arc::new(paths);
@@ -679,12 +701,36 @@ fn bench_concurrent_require(c: &mut Criterion) {
             |b, &num_threads| {
                 let fs = Arc::new(Mutex::new(create_rails_app_fs()));
                 let paths: Vec<Vec<&'static OsStr>> = vec![
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb")],
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model1.rb")],
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model2.rb")],
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model3.rb")],
-                    vec![OsStr::new("app"), OsStr::new("controllers"), OsStr::new("controller0.rb")],
-                    vec![OsStr::new("app"), OsStr::new("controllers"), OsStr::new("controller1.rb")],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model0.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model1.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model2.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model3.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("controllers"),
+                        OsStr::new("controller0.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("controllers"),
+                        OsStr::new("controller1.rb"),
+                    ],
                     vec![OsStr::new("config"), OsStr::new("routes.rb")],
                     vec![OsStr::new("config"), OsStr::new("application.rb")],
                 ];
@@ -750,11 +796,19 @@ fn bench_concurrent_mixed_workload(c: &mut Criterion) {
             |b, &num_threads| {
                 let fs = Arc::new(Mutex::new(create_rails_app_fs()));
                 let stat_paths: Vec<Vec<&'static OsStr>> = vec![
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb")],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model0.rb"),
+                    ],
                     vec![OsStr::new("config"), OsStr::new("routes.rb")],
                 ];
                 let require_paths: Vec<Vec<&'static OsStr>> = vec![
-                    vec![OsStr::new("app"), OsStr::new("controllers"), OsStr::new("controller0.rb")],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("controllers"),
+                        OsStr::new("controller0.rb"),
+                    ],
                     vec![OsStr::new("lib"), OsStr::new("lib0.rb")],
                 ];
                 let stat_paths = Arc::new(stat_paths);
@@ -773,7 +827,8 @@ fn bench_concurrent_mixed_workload(c: &mut Criterion) {
                                     for _ in 0..10 {
                                         let path = &stat_paths[i / 2 % stat_paths.len()];
                                         let fs = fs.lock().unwrap();
-                                        let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+                                        let mut stat_buf: libc::stat =
+                                            unsafe { std::mem::zeroed() };
                                         fs.stat(black_box(path), &mut stat_buf);
                                     }
                                 } else {
@@ -878,13 +933,26 @@ fn bench_rwlock_stat(c: &mut Criterion) {
             |b, &num_threads| {
                 let fs = Arc::new(Mutex::new(create_rails_app_fs()));
                 let paths: Vec<Vec<&'static OsStr>> = vec![
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb")],
-                    vec![OsStr::new("app"), OsStr::new("controllers"), OsStr::new("controller0.rb")],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model0.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("controllers"),
+                        OsStr::new("controller0.rb"),
+                    ],
                     vec![OsStr::new("config"), OsStr::new("routes.rb")],
                     vec![
-                        OsStr::new("vendor"), OsStr::new("bundle"), OsStr::new("ruby"),
-                        OsStr::new("3.2.0"), OsStr::new("gems"), OsStr::new("rails"),
-                        OsStr::new("lib"), OsStr::new("rails0.rb"),
+                        OsStr::new("vendor"),
+                        OsStr::new("bundle"),
+                        OsStr::new("ruby"),
+                        OsStr::new("3.2.0"),
+                        OsStr::new("gems"),
+                        OsStr::new("rails"),
+                        OsStr::new("lib"),
+                        OsStr::new("rails0.rb"),
                     ],
                 ];
                 let paths = Arc::new(paths);
@@ -917,13 +985,26 @@ fn bench_rwlock_stat(c: &mut Criterion) {
             |b, &num_threads| {
                 let fs = Arc::new(RwLock::new(create_rails_app_fs()));
                 let paths: Vec<Vec<&'static OsStr>> = vec![
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb")],
-                    vec![OsStr::new("app"), OsStr::new("controllers"), OsStr::new("controller0.rb")],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model0.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("controllers"),
+                        OsStr::new("controller0.rb"),
+                    ],
                     vec![OsStr::new("config"), OsStr::new("routes.rb")],
                     vec![
-                        OsStr::new("vendor"), OsStr::new("bundle"), OsStr::new("ruby"),
-                        OsStr::new("3.2.0"), OsStr::new("gems"), OsStr::new("rails"),
-                        OsStr::new("lib"), OsStr::new("rails0.rb"),
+                        OsStr::new("vendor"),
+                        OsStr::new("bundle"),
+                        OsStr::new("ruby"),
+                        OsStr::new("3.2.0"),
+                        OsStr::new("gems"),
+                        OsStr::new("rails"),
+                        OsStr::new("lib"),
+                        OsStr::new("rails0.rb"),
                     ],
                 ];
                 let paths = Arc::new(paths);
@@ -967,10 +1048,26 @@ fn bench_rwlock_require(c: &mut Criterion) {
             |b, &num_threads| {
                 let fs = Arc::new(Mutex::new(create_rails_app_fs()));
                 let paths: Vec<Vec<&'static OsStr>> = vec![
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb")],
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model1.rb")],
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model2.rb")],
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model3.rb")],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model0.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model1.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model2.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model3.rb"),
+                    ],
                 ];
                 let paths = Arc::new(paths);
 
@@ -1026,10 +1123,26 @@ fn bench_rwlock_require(c: &mut Criterion) {
             |b, &num_threads| {
                 let fs = Arc::new(RwLock::new(create_rails_app_fs()));
                 let paths: Vec<Vec<&'static OsStr>> = vec![
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb")],
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model1.rb")],
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model2.rb")],
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model3.rb")],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model0.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model1.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model2.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model3.rb"),
+                    ],
                 ];
                 let paths = Arc::new(paths);
 
@@ -1094,10 +1207,14 @@ fn bench_rwlock_read_heavy(c: &mut Criterion) {
     group.bench_function("mutex", |b| {
         let fs = Arc::new(Mutex::new(create_rails_app_fs()));
         let stat_path: Vec<&'static OsStr> = vec![
-            OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb"),
+            OsStr::new("app"),
+            OsStr::new("models"),
+            OsStr::new("model0.rb"),
         ];
         let require_path: Vec<&'static OsStr> = vec![
-            OsStr::new("app"), OsStr::new("controllers"), OsStr::new("controller0.rb"),
+            OsStr::new("app"),
+            OsStr::new("controllers"),
+            OsStr::new("controller0.rb"),
         ];
         let stat_path = Arc::new(stat_path);
         let require_path = Arc::new(require_path);
@@ -1149,10 +1266,14 @@ fn bench_rwlock_read_heavy(c: &mut Criterion) {
     group.bench_function("rwlock", |b| {
         let fs = Arc::new(RwLock::new(create_rails_app_fs()));
         let stat_path: Vec<&'static OsStr> = vec![
-            OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb"),
+            OsStr::new("app"),
+            OsStr::new("models"),
+            OsStr::new("model0.rb"),
         ];
         let require_path: Vec<&'static OsStr> = vec![
-            OsStr::new("app"), OsStr::new("controllers"), OsStr::new("controller0.rb"),
+            OsStr::new("app"),
+            OsStr::new("controllers"),
+            OsStr::new("controller0.rb"),
         ];
         let stat_path = Arc::new(stat_path);
         let require_path = Arc::new(require_path);
@@ -1217,7 +1338,9 @@ fn bench_internal_rwlock(c: &mut Criterion) {
             |b, &num_threads| {
                 let fs = Arc::new(Mutex::new(create_rails_app_fs()));
                 let path: Vec<&'static OsStr> = vec![
-                    OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb"),
+                    OsStr::new("app"),
+                    OsStr::new("models"),
+                    OsStr::new("model0.rb"),
                 ];
                 let path = Arc::new(path);
 
@@ -1251,7 +1374,9 @@ fn bench_internal_rwlock(c: &mut Criterion) {
             |b, &num_threads| {
                 let fs = Arc::new(create_rails_app_fs());
                 let path: Vec<&'static OsStr> = vec![
-                    OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb"),
+                    OsStr::new("app"),
+                    OsStr::new("models"),
+                    OsStr::new("model0.rb"),
                 ];
                 let path = Arc::new(path);
 
@@ -1284,10 +1409,26 @@ fn bench_internal_rwlock(c: &mut Criterion) {
             |b, &num_threads| {
                 let fs = Arc::new(Mutex::new(create_rails_app_fs()));
                 let paths: Vec<Vec<&'static OsStr>> = vec![
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb")],
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model1.rb")],
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model2.rb")],
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model3.rb")],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model0.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model1.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model2.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model3.rb"),
+                    ],
                 ];
                 let paths = Arc::new(paths);
 
@@ -1327,10 +1468,26 @@ fn bench_internal_rwlock(c: &mut Criterion) {
             |b, &num_threads| {
                 let fs = Arc::new(create_rails_app_fs());
                 let paths: Vec<Vec<&'static OsStr>> = vec![
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb")],
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model1.rb")],
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model2.rb")],
-                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model3.rb")],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model0.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model1.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model2.rb"),
+                    ],
+                    vec![
+                        OsStr::new("app"),
+                        OsStr::new("models"),
+                        OsStr::new("model3.rb"),
+                    ],
                 ];
                 let paths = Arc::new(paths);
 
@@ -1379,7 +1536,9 @@ fn bench_rwlock_stat_only(c: &mut Criterion) {
             |b, &num_threads| {
                 let fs = Arc::new(Mutex::new(create_rails_app_fs()));
                 let path: Vec<&'static OsStr> = vec![
-                    OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb"),
+                    OsStr::new("app"),
+                    OsStr::new("models"),
+                    OsStr::new("model0.rb"),
                 ];
                 let path = Arc::new(path);
 
@@ -1412,7 +1571,9 @@ fn bench_rwlock_stat_only(c: &mut Criterion) {
             |b, &num_threads| {
                 let fs = Arc::new(RwLock::new(create_rails_app_fs()));
                 let path: Vec<&'static OsStr> = vec![
-                    OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb"),
+                    OsStr::new("app"),
+                    OsStr::new("models"),
+                    OsStr::new("model0.rb"),
                 ];
                 let path = Arc::new(path);
 

--- a/kompo_storage/benches/fs_bench.rs
+++ b/kompo_storage/benches/fs_bench.rs
@@ -1,0 +1,1465 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use kompo_storage::Fs;
+use std::ffi::OsStr;
+use std::hint::black_box;
+use std::sync::{Arc, Mutex, RwLock};
+use std::thread;
+use trie_rs::map::TrieBuilder;
+
+// Realistic file sizes based on actual Ruby/Rails codebases
+static SMALL_CONTENT: &[u8] = &[b'#'; 512]; // Config files, small modules (~500B)
+static MEDIUM_CONTENT: &[u8] = &[b'#'; 4096]; // Typical Ruby source files (~4KB)
+static LARGE_CONTENT: &[u8] = &[b'#'; 32768]; // Large library files (~32KB)
+static XLARGE_CONTENT: &[u8] = &[b'#'; 131072]; // Very large files (~128KB)
+
+/// Create a realistic Rails application filesystem
+/// Simulates a medium-sized Rails app with bundled gems
+/// Total: ~15,000 files (typical for Rails app + dependencies)
+fn create_rails_app_fs() -> Fs<'static> {
+    let mut builder: TrieBuilder<&OsStr, &[u8]> = TrieBuilder::new();
+
+    // App directory structure (typical Rails app: ~200 files)
+    let app_dirs = ["models", "controllers", "views", "helpers", "jobs", "mailers", "channels"];
+    for dir in app_dirs {
+        for i in 0..30 {
+            let file = format!("{}{}.rb", dir.trim_end_matches('s'), i);
+            let file_leaked: &'static str = Box::leak(file.into_boxed_str());
+            let dir_leaked: &'static str = Box::leak(dir.to_string().into_boxed_str());
+            let path: Vec<&OsStr> = vec![
+                OsStr::new("app"),
+                OsStr::new(dir_leaked),
+                OsStr::new(file_leaked),
+            ];
+            builder.push(&path, MEDIUM_CONTENT);
+        }
+    }
+
+    // Nested controllers (API versioning)
+    for version in ["v1", "v2"] {
+        for i in 0..20 {
+            let file = format!("controller{}.rb", i);
+            let file_leaked: &'static str = Box::leak(file.into_boxed_str());
+            let version_leaked: &'static str = Box::leak(version.to_string().into_boxed_str());
+            let path: Vec<&OsStr> = vec![
+                OsStr::new("app"),
+                OsStr::new("controllers"),
+                OsStr::new("api"),
+                OsStr::new(version_leaked),
+                OsStr::new(file_leaked),
+            ];
+            builder.push(&path, MEDIUM_CONTENT);
+        }
+    }
+
+    // Config files (~50 files)
+    let config_files = [
+        "application.rb",
+        "environment.rb",
+        "routes.rb",
+        "database.yml",
+        "secrets.yml",
+        "cable.yml",
+        "storage.yml",
+        "puma.rb",
+    ];
+    for file in config_files {
+        let path: Vec<&OsStr> = vec![OsStr::new("config"), OsStr::new(file)];
+        builder.push(&path, SMALL_CONTENT);
+    }
+
+    // Config/initializers
+    for i in 0..20 {
+        let file = format!("initializer{}.rb", i);
+        let file_leaked: &'static str = Box::leak(file.into_boxed_str());
+        let path: Vec<&OsStr> = vec![
+            OsStr::new("config"),
+            OsStr::new("initializers"),
+            OsStr::new(file_leaked),
+        ];
+        builder.push(&path, SMALL_CONTENT);
+    }
+
+    // Lib directory (~100 files)
+    for i in 0..50 {
+        let file = format!("lib{}.rb", i);
+        let file_leaked: &'static str = Box::leak(file.into_boxed_str());
+        let path: Vec<&OsStr> = vec![OsStr::new("lib"), OsStr::new(file_leaked)];
+        builder.push(&path, MEDIUM_CONTENT);
+    }
+
+    // Vendor/bundle gems (the bulk: ~14,000 files simulating ~200 gems)
+    let popular_gems = [
+        "rails",
+        "activerecord",
+        "actionpack",
+        "activesupport",
+        "actionview",
+        "actionmailer",
+        "activejob",
+        "actioncable",
+        "railties",
+        "bundler",
+        "rake",
+        "thor",
+        "i18n",
+        "tzinfo",
+        "concurrent-ruby",
+        "sprockets",
+        "sass-rails",
+        "uglifier",
+        "turbolinks",
+        "jbuilder",
+        "puma",
+        "bootsnap",
+        "byebug",
+        "web-console",
+        "listen",
+        "spring",
+        "capybara",
+        "selenium-webdriver",
+        "rspec-rails",
+        "factory_bot",
+        "faker",
+        "devise",
+        "pundit",
+        "sidekiq",
+        "redis",
+        "pg",
+        "aws-sdk-s3",
+        "paperclip",
+        "carrierwave",
+        "mini_magick",
+    ];
+
+    for gem in popular_gems {
+        let gem_leaked: &'static str = Box::leak(gem.to_string().into_boxed_str());
+
+        // Each gem has ~50-200 files
+        let file_count = match gem {
+            "rails" | "activerecord" | "actionpack" | "activesupport" => 200,
+            "aws-sdk-s3" => 150,
+            _ => 50,
+        };
+
+        // Main lib files
+        for i in 0..file_count {
+            let file = format!("{}{}.rb", gem.replace('-', "_"), i);
+            let file_leaked: &'static str = Box::leak(file.into_boxed_str());
+            let content = if i < 5 { LARGE_CONTENT } else { MEDIUM_CONTENT };
+
+            let path: Vec<&OsStr> = vec![
+                OsStr::new("vendor"),
+                OsStr::new("bundle"),
+                OsStr::new("ruby"),
+                OsStr::new("3.2.0"),
+                OsStr::new("gems"),
+                OsStr::new(gem_leaked),
+                OsStr::new("lib"),
+                OsStr::new(file_leaked),
+            ];
+            builder.push(&path, content);
+        }
+
+        // Nested lib directories (common in larger gems)
+        if file_count > 100 {
+            for subdir in ["core", "util", "ext"] {
+                for i in 0..20 {
+                    let file = format!("{}{}.rb", subdir, i);
+                    let file_leaked: &'static str = Box::leak(file.into_boxed_str());
+                    let subdir_leaked: &'static str = Box::leak(subdir.to_string().into_boxed_str());
+                    let path: Vec<&OsStr> = vec![
+                        OsStr::new("vendor"),
+                        OsStr::new("bundle"),
+                        OsStr::new("ruby"),
+                        OsStr::new("3.2.0"),
+                        OsStr::new("gems"),
+                        OsStr::new(gem_leaked),
+                        OsStr::new("lib"),
+                        OsStr::new(subdir_leaked),
+                        OsStr::new(file_leaked),
+                    ];
+                    builder.push(&path, MEDIUM_CONTENT);
+                }
+            }
+        }
+    }
+
+    Fs::new(builder)
+}
+
+// ============================================================================
+// Realistic scenario benchmarks
+// ============================================================================
+
+fn bench_require_simulation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("require_simulation");
+
+    // Simulate Ruby's require: stat -> open -> read -> close
+    group.bench_function("app_model", |b| {
+        let fs = create_rails_app_fs();
+        let path: Vec<&OsStr> = vec![
+            OsStr::new("app"),
+            OsStr::new("models"),
+            OsStr::new("model0.rb"),
+        ];
+        b.iter(|| {
+            // stat to check existence
+            let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+            fs.stat(black_box(&path), &mut stat_buf);
+
+            // open, read, close
+            let fd = fs.open(&path).unwrap();
+            let mut buf = [0u8; 8192];
+            while fs.read(fd, &mut buf).unwrap_or(0) > 0 {}
+            fs.close(fd);
+            unsafe { libc::close(fd) };
+        })
+    });
+
+    group.bench_function("gem_lib_deep", |b| {
+        let fs = create_rails_app_fs();
+        let path: Vec<&OsStr> = vec![
+            OsStr::new("vendor"),
+            OsStr::new("bundle"),
+            OsStr::new("ruby"),
+            OsStr::new("3.2.0"),
+            OsStr::new("gems"),
+            OsStr::new("rails"),
+            OsStr::new("lib"),
+            OsStr::new("rails0.rb"),
+        ];
+        b.iter(|| {
+            let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+            fs.stat(black_box(&path), &mut stat_buf);
+
+            let fd = fs.open(&path).unwrap();
+            let mut buf = [0u8; 8192];
+            while fs.read(fd, &mut buf).unwrap_or(0) > 0 {}
+            fs.close(fd);
+            unsafe { libc::close(fd) };
+        })
+    });
+
+    group.bench_function("gem_lib_nested", |b| {
+        let fs = create_rails_app_fs();
+        let path: Vec<&OsStr> = vec![
+            OsStr::new("vendor"),
+            OsStr::new("bundle"),
+            OsStr::new("ruby"),
+            OsStr::new("3.2.0"),
+            OsStr::new("gems"),
+            OsStr::new("activerecord"),
+            OsStr::new("lib"),
+            OsStr::new("core"),
+            OsStr::new("core0.rb"),
+        ];
+        b.iter(|| {
+            let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+            fs.stat(black_box(&path), &mut stat_buf);
+
+            let fd = fs.open(&path).unwrap();
+            let mut buf = [0u8; 8192];
+            while fs.read(fd, &mut buf).unwrap_or(0) > 0 {}
+            fs.close(fd);
+            unsafe { libc::close(fd) };
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_dir_glob_simulation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dir_glob_simulation");
+
+    // Simulate Dir.glob pattern: opendir -> readdir* -> closedir
+    group.bench_function("app_models_dir", |b| {
+        let fs = create_rails_app_fs();
+        let path: Vec<&OsStr> = vec![OsStr::new("app"), OsStr::new("models")];
+        b.iter(|| {
+            let mut dir = fs.opendir(black_box(&path)).unwrap();
+            let mut count = 0;
+            while let Some(entry) = fs.readdir(&mut dir) {
+                if entry.is_null() {
+                    break;
+                }
+                count += 1;
+                unsafe { drop(Box::from_raw(entry)) };
+            }
+            let fd = dir.fd;
+            fs.closedir(&dir);
+            unsafe { libc::close(fd) };
+            count
+        })
+    });
+
+    group.bench_function("gem_lib_dir_large", |b| {
+        let fs = create_rails_app_fs();
+        let path: Vec<&OsStr> = vec![
+            OsStr::new("vendor"),
+            OsStr::new("bundle"),
+            OsStr::new("ruby"),
+            OsStr::new("3.2.0"),
+            OsStr::new("gems"),
+            OsStr::new("rails"),
+            OsStr::new("lib"),
+        ];
+        b.iter(|| {
+            let mut dir = fs.opendir(black_box(&path)).unwrap();
+            let mut count = 0;
+            while let Some(entry) = fs.readdir(&mut dir) {
+                if entry.is_null() {
+                    break;
+                }
+                count += 1;
+                unsafe { drop(Box::from_raw(entry)) };
+            }
+            let fd = dir.fd;
+            fs.closedir(&dir);
+            unsafe { libc::close(fd) };
+            count
+        })
+    });
+
+    group.bench_function("gems_dir", |b| {
+        let fs = create_rails_app_fs();
+        let path: Vec<&OsStr> = vec![
+            OsStr::new("vendor"),
+            OsStr::new("bundle"),
+            OsStr::new("ruby"),
+            OsStr::new("3.2.0"),
+            OsStr::new("gems"),
+        ];
+        b.iter(|| {
+            let mut dir = fs.opendir(black_box(&path)).unwrap();
+            let mut count = 0;
+            while let Some(entry) = fs.readdir(&mut dir) {
+                if entry.is_null() {
+                    break;
+                }
+                count += 1;
+                unsafe { drop(Box::from_raw(entry)) };
+            }
+            let fd = dir.fd;
+            fs.closedir(&dir);
+            unsafe { libc::close(fd) };
+            count
+        })
+    });
+
+    group.finish();
+}
+
+// ============================================================================
+// File size benchmarks
+// ============================================================================
+
+fn bench_read_by_size(c: &mut Criterion) {
+    let mut group = c.benchmark_group("read_by_size");
+
+    let sizes = [
+        ("512B", SMALL_CONTENT),
+        ("4KB", MEDIUM_CONTENT),
+        ("32KB", LARGE_CONTENT),
+        ("128KB", XLARGE_CONTENT),
+    ];
+
+    for (name, content) in sizes {
+        group.throughput(Throughput::Bytes(content.len() as u64));
+        group.bench_with_input(BenchmarkId::new("read", name), &content, |b, &content| {
+            let mut builder: TrieBuilder<&OsStr, &[u8]> = TrieBuilder::new();
+            let path: Vec<&OsStr> = vec![OsStr::new("test"), OsStr::new("file.rb")];
+            builder.push(&path, content);
+            let fs = Fs::new(builder);
+
+            b.iter(|| {
+                let fd = fs.open(&path).unwrap();
+                let mut buf = [0u8; 8192];
+                let mut total = 0;
+                while let Some(n) = fs.read(fd, &mut buf) {
+                    if n == 0 {
+                        break;
+                    }
+                    total += n;
+                }
+                fs.close(fd);
+                unsafe { libc::close(fd) };
+                total
+            })
+        });
+    }
+
+    group.finish();
+}
+
+// ============================================================================
+// Path depth benchmarks
+// ============================================================================
+
+fn bench_stat_by_depth(c: &mut Criterion) {
+    let mut group = c.benchmark_group("stat_by_depth");
+
+    let fs = create_rails_app_fs();
+
+    // Depth 2: config/routes.rb
+    let depth2: Vec<&OsStr> = vec![OsStr::new("config"), OsStr::new("routes.rb")];
+    group.bench_function("depth_2", |b| {
+        b.iter(|| {
+            let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+            fs.stat(black_box(&depth2), &mut stat_buf)
+        })
+    });
+
+    // Depth 3: app/models/model0.rb
+    let depth3: Vec<&OsStr> = vec![
+        OsStr::new("app"),
+        OsStr::new("models"),
+        OsStr::new("model0.rb"),
+    ];
+    group.bench_function("depth_3", |b| {
+        b.iter(|| {
+            let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+            fs.stat(black_box(&depth3), &mut stat_buf)
+        })
+    });
+
+    // Depth 5: app/controllers/api/v1/controller0.rb
+    let depth5: Vec<&OsStr> = vec![
+        OsStr::new("app"),
+        OsStr::new("controllers"),
+        OsStr::new("api"),
+        OsStr::new("v1"),
+        OsStr::new("controller0.rb"),
+    ];
+    group.bench_function("depth_5", |b| {
+        b.iter(|| {
+            let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+            fs.stat(black_box(&depth5), &mut stat_buf)
+        })
+    });
+
+    // Depth 8: vendor/bundle/ruby/3.2.0/gems/rails/lib/rails0.rb
+    let depth8: Vec<&OsStr> = vec![
+        OsStr::new("vendor"),
+        OsStr::new("bundle"),
+        OsStr::new("ruby"),
+        OsStr::new("3.2.0"),
+        OsStr::new("gems"),
+        OsStr::new("rails"),
+        OsStr::new("lib"),
+        OsStr::new("rails0.rb"),
+    ];
+    group.bench_function("depth_8", |b| {
+        b.iter(|| {
+            let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+            fs.stat(black_box(&depth8), &mut stat_buf)
+        })
+    });
+
+    // Depth 9: vendor/bundle/ruby/3.2.0/gems/activerecord/lib/core/core0.rb
+    let depth9: Vec<&OsStr> = vec![
+        OsStr::new("vendor"),
+        OsStr::new("bundle"),
+        OsStr::new("ruby"),
+        OsStr::new("3.2.0"),
+        OsStr::new("gems"),
+        OsStr::new("activerecord"),
+        OsStr::new("lib"),
+        OsStr::new("core"),
+        OsStr::new("core0.rb"),
+    ];
+    group.bench_function("depth_9", |b| {
+        b.iter(|| {
+            let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+            fs.stat(black_box(&depth9), &mut stat_buf)
+        })
+    });
+
+    group.finish();
+}
+
+// ============================================================================
+// Scalability benchmarks (file count)
+// ============================================================================
+
+fn create_scaled_fs(file_count: usize) -> Fs<'static> {
+    let mut builder: TrieBuilder<&OsStr, &[u8]> = TrieBuilder::new();
+
+    // Distribute files across realistic directory structure
+    let files_per_gem = 50;
+
+    for i in 0..file_count {
+        let gem_idx = i / files_per_gem;
+        let file_idx = i % files_per_gem;
+
+        let gem = format!("gem{}", gem_idx);
+        let file = format!("file{}.rb", file_idx);
+        let gem_leaked: &'static str = Box::leak(gem.into_boxed_str());
+        let file_leaked: &'static str = Box::leak(file.into_boxed_str());
+
+        let path: Vec<&OsStr> = vec![
+            OsStr::new("vendor"),
+            OsStr::new("bundle"),
+            OsStr::new("ruby"),
+            OsStr::new("3.2.0"),
+            OsStr::new("gems"),
+            OsStr::new(gem_leaked),
+            OsStr::new("lib"),
+            OsStr::new(file_leaked),
+        ];
+        builder.push(&path, MEDIUM_CONTENT);
+    }
+
+    Fs::new(builder)
+}
+
+fn bench_scalability(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scalability");
+
+    // Test with realistic file counts
+    for file_count in [1000, 5000, 10000, 20000, 50000] {
+        group.bench_with_input(
+            BenchmarkId::new("stat", file_count),
+            &file_count,
+            |b, &count| {
+                let fs = create_scaled_fs(count);
+                // Access a file in the middle of the filesystem
+                let gem_idx = count / 100; // Middle gem
+                let gem = format!("gem{}", gem_idx);
+                let gem_leaked: &'static str = Box::leak(gem.into_boxed_str());
+
+                let path: Vec<&OsStr> = vec![
+                    OsStr::new("vendor"),
+                    OsStr::new("bundle"),
+                    OsStr::new("ruby"),
+                    OsStr::new("3.2.0"),
+                    OsStr::new("gems"),
+                    OsStr::new(gem_leaked),
+                    OsStr::new("lib"),
+                    OsStr::new("file25.rb"),
+                ];
+                b.iter(|| {
+                    let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+                    fs.stat(black_box(&path), &mut stat_buf)
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// ============================================================================
+// Basic operation benchmarks (isolated)
+// ============================================================================
+
+fn bench_basic_operations(c: &mut Criterion) {
+    let mut group = c.benchmark_group("basic_ops");
+
+    // Pure stat (no file content)
+    group.bench_function("stat_only", |b| {
+        let fs = create_rails_app_fs();
+        let path: Vec<&OsStr> = vec![
+            OsStr::new("app"),
+            OsStr::new("models"),
+            OsStr::new("model0.rb"),
+        ];
+        b.iter(|| {
+            let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+            fs.stat(black_box(&path), &mut stat_buf)
+        })
+    });
+
+    // Pure fstat (fd lookup)
+    group.bench_function("fstat_only", |b| {
+        let fs = create_rails_app_fs();
+        let path: Vec<&OsStr> = vec![
+            OsStr::new("app"),
+            OsStr::new("models"),
+            OsStr::new("model0.rb"),
+        ];
+        let fd = fs.open(&path).unwrap();
+        b.iter(|| {
+            let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+            fs.fstat(black_box(fd), &mut stat_buf)
+        })
+    });
+
+    // stat nonexistent (early return)
+    group.bench_function("stat_nonexistent", |b| {
+        let fs = create_rails_app_fs();
+        let path: Vec<&OsStr> = vec![
+            OsStr::new("nonexistent"),
+            OsStr::new("path"),
+            OsStr::new("file.rb"),
+        ];
+        b.iter(|| {
+            let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+            fs.stat(black_box(&path), &mut stat_buf)
+        })
+    });
+
+    // Pure open/close cycle
+    group.bench_function("open_close_only", |b| {
+        let fs = create_rails_app_fs();
+        let path: Vec<&OsStr> = vec![
+            OsStr::new("app"),
+            OsStr::new("models"),
+            OsStr::new("model0.rb"),
+        ];
+        b.iter(|| {
+            let fd = fs.open(black_box(&path)).unwrap();
+            fs.close(fd);
+            unsafe { libc::close(fd) };
+        })
+    });
+
+    group.finish();
+}
+
+// ============================================================================
+// Concurrent access benchmarks (simulating kompo_fs usage with Mutex)
+// ============================================================================
+
+fn bench_concurrent_stat(c: &mut Criterion) {
+    let mut group = c.benchmark_group("concurrent_stat");
+
+    // Test with different thread counts
+    for num_threads in [1, 2, 4, 8] {
+        group.bench_with_input(
+            BenchmarkId::new("threads", num_threads),
+            &num_threads,
+            |b, &num_threads| {
+                let fs = Arc::new(Mutex::new(create_rails_app_fs()));
+                let paths: Vec<Vec<&'static OsStr>> = vec![
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb")],
+                    vec![OsStr::new("app"), OsStr::new("controllers"), OsStr::new("controller0.rb")],
+                    vec![OsStr::new("config"), OsStr::new("routes.rb")],
+                    vec![
+                        OsStr::new("vendor"), OsStr::new("bundle"), OsStr::new("ruby"),
+                        OsStr::new("3.2.0"), OsStr::new("gems"), OsStr::new("rails"),
+                        OsStr::new("lib"), OsStr::new("rails0.rb"),
+                    ],
+                ];
+                let paths = Arc::new(paths);
+
+                b.iter(|| {
+                    let handles: Vec<_> = (0..num_threads)
+                        .map(|i| {
+                            let fs = Arc::clone(&fs);
+                            let paths = Arc::clone(&paths);
+                            thread::spawn(move || {
+                                let path = &paths[i % paths.len()];
+                                let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+                                // Acquire lock for each stat call (simulating real usage)
+                                let fs = fs.lock().unwrap();
+                                fs.stat(black_box(path), &mut stat_buf)
+                            })
+                        })
+                        .collect();
+
+                    for handle in handles {
+                        handle.join().unwrap();
+                    }
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_concurrent_require(c: &mut Criterion) {
+    let mut group = c.benchmark_group("concurrent_require");
+
+    // Simulate multiple threads requiring files (like Ruby's require)
+    for num_threads in [1, 2, 4, 8] {
+        group.bench_with_input(
+            BenchmarkId::new("threads", num_threads),
+            &num_threads,
+            |b, &num_threads| {
+                let fs = Arc::new(Mutex::new(create_rails_app_fs()));
+                let paths: Vec<Vec<&'static OsStr>> = vec![
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb")],
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model1.rb")],
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model2.rb")],
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model3.rb")],
+                    vec![OsStr::new("app"), OsStr::new("controllers"), OsStr::new("controller0.rb")],
+                    vec![OsStr::new("app"), OsStr::new("controllers"), OsStr::new("controller1.rb")],
+                    vec![OsStr::new("config"), OsStr::new("routes.rb")],
+                    vec![OsStr::new("config"), OsStr::new("application.rb")],
+                ];
+                let paths = Arc::new(paths);
+
+                b.iter(|| {
+                    let handles: Vec<_> = (0..num_threads)
+                        .map(|i| {
+                            let fs = Arc::clone(&fs);
+                            let paths = Arc::clone(&paths);
+                            thread::spawn(move || {
+                                let path = &paths[i % paths.len()];
+
+                                // stat
+                                {
+                                    let fs = fs.lock().unwrap();
+                                    let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+                                    fs.stat(black_box(path), &mut stat_buf);
+                                }
+
+                                // open
+                                let fd = {
+                                    let fs = fs.lock().unwrap();
+                                    fs.open(path).unwrap()
+                                };
+
+                                // read
+                                {
+                                    let fs = fs.lock().unwrap();
+                                    let mut buf = [0u8; 8192];
+                                    while fs.read(fd, &mut buf).unwrap_or(0) > 0 {}
+                                }
+
+                                // close
+                                {
+                                    let fs = fs.lock().unwrap();
+                                    fs.close(fd);
+                                }
+                                unsafe { libc::close(fd) };
+                            })
+                        })
+                        .collect();
+
+                    for handle in handles {
+                        handle.join().unwrap();
+                    }
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_concurrent_mixed_workload(c: &mut Criterion) {
+    let mut group = c.benchmark_group("concurrent_mixed");
+
+    // Mixed workload: some threads do stat, some do full require cycle
+    for num_threads in [2, 4, 8] {
+        group.bench_with_input(
+            BenchmarkId::new("threads", num_threads),
+            &num_threads,
+            |b, &num_threads| {
+                let fs = Arc::new(Mutex::new(create_rails_app_fs()));
+                let stat_paths: Vec<Vec<&'static OsStr>> = vec![
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb")],
+                    vec![OsStr::new("config"), OsStr::new("routes.rb")],
+                ];
+                let require_paths: Vec<Vec<&'static OsStr>> = vec![
+                    vec![OsStr::new("app"), OsStr::new("controllers"), OsStr::new("controller0.rb")],
+                    vec![OsStr::new("lib"), OsStr::new("lib0.rb")],
+                ];
+                let stat_paths = Arc::new(stat_paths);
+                let require_paths = Arc::new(require_paths);
+
+                b.iter(|| {
+                    let handles: Vec<_> = (0..num_threads)
+                        .map(|i| {
+                            let fs = Arc::clone(&fs);
+                            let stat_paths = Arc::clone(&stat_paths);
+                            let require_paths = Arc::clone(&require_paths);
+
+                            thread::spawn(move || {
+                                if i % 2 == 0 {
+                                    // stat-only thread (read-heavy)
+                                    for _ in 0..10 {
+                                        let path = &stat_paths[i / 2 % stat_paths.len()];
+                                        let fs = fs.lock().unwrap();
+                                        let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+                                        fs.stat(black_box(path), &mut stat_buf);
+                                    }
+                                } else {
+                                    // require thread (read + write)
+                                    let path = &require_paths[i / 2 % require_paths.len()];
+
+                                    let fd = {
+                                        let fs = fs.lock().unwrap();
+                                        fs.open(path).unwrap()
+                                    };
+
+                                    {
+                                        let fs = fs.lock().unwrap();
+                                        let mut buf = [0u8; 8192];
+                                        while fs.read(fd, &mut buf).unwrap_or(0) > 0 {}
+                                    }
+
+                                    {
+                                        let fs = fs.lock().unwrap();
+                                        fs.close(fd);
+                                    }
+                                    unsafe { libc::close(fd) };
+                                }
+                            })
+                        })
+                        .collect();
+
+                    for handle in handles {
+                        handle.join().unwrap();
+                    }
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_lock_contention(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lock_contention");
+
+    // Compare single-threaded with vs without Mutex overhead
+    group.bench_function("without_mutex", |b| {
+        let fs = create_rails_app_fs();
+        let path: Vec<&OsStr> = vec![
+            OsStr::new("app"),
+            OsStr::new("models"),
+            OsStr::new("model0.rb"),
+        ];
+        b.iter(|| {
+            let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+            fs.stat(black_box(&path), &mut stat_buf)
+        })
+    });
+
+    group.bench_function("with_mutex_uncontended", |b| {
+        let fs = Mutex::new(create_rails_app_fs());
+        let path: Vec<&OsStr> = vec![
+            OsStr::new("app"),
+            OsStr::new("models"),
+            OsStr::new("model0.rb"),
+        ];
+        b.iter(|| {
+            let fs = fs.lock().unwrap();
+            let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+            fs.stat(black_box(&path), &mut stat_buf)
+        })
+    });
+
+    group.bench_function("with_rwlock_uncontended", |b| {
+        let fs = RwLock::new(create_rails_app_fs());
+        let path: Vec<&OsStr> = vec![
+            OsStr::new("app"),
+            OsStr::new("models"),
+            OsStr::new("model0.rb"),
+        ];
+        b.iter(|| {
+            let fs = fs.read().unwrap();
+            let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+            fs.stat(black_box(&path), &mut stat_buf)
+        })
+    });
+
+    group.finish();
+}
+
+// ============================================================================
+// RwLock benchmarks (comparing Mutex vs RwLock for concurrent access)
+// After implementing internal RwLock, change Arc<RwLock<Fs>> to Arc<Fs>
+// ============================================================================
+
+/// Benchmark concurrent stat with RwLock (read lock only)
+/// stat is read-only, so RwLock should allow parallel reads
+fn bench_rwlock_stat(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rwlock_stat");
+
+    for num_threads in [1, 2, 4, 8] {
+        // Mutex baseline
+        group.bench_with_input(
+            BenchmarkId::new("mutex", num_threads),
+            &num_threads,
+            |b, &num_threads| {
+                let fs = Arc::new(Mutex::new(create_rails_app_fs()));
+                let paths: Vec<Vec<&'static OsStr>> = vec![
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb")],
+                    vec![OsStr::new("app"), OsStr::new("controllers"), OsStr::new("controller0.rb")],
+                    vec![OsStr::new("config"), OsStr::new("routes.rb")],
+                    vec![
+                        OsStr::new("vendor"), OsStr::new("bundle"), OsStr::new("ruby"),
+                        OsStr::new("3.2.0"), OsStr::new("gems"), OsStr::new("rails"),
+                        OsStr::new("lib"), OsStr::new("rails0.rb"),
+                    ],
+                ];
+                let paths = Arc::new(paths);
+
+                b.iter(|| {
+                    let handles: Vec<_> = (0..num_threads)
+                        .map(|i| {
+                            let fs = Arc::clone(&fs);
+                            let paths = Arc::clone(&paths);
+                            thread::spawn(move || {
+                                let path = &paths[i % paths.len()];
+                                let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+                                let fs = fs.lock().unwrap();
+                                fs.stat(black_box(path), &mut stat_buf)
+                            })
+                        })
+                        .collect();
+
+                    for handle in handles {
+                        handle.join().unwrap();
+                    }
+                })
+            },
+        );
+
+        // RwLock (read lock for stat)
+        group.bench_with_input(
+            BenchmarkId::new("rwlock", num_threads),
+            &num_threads,
+            |b, &num_threads| {
+                let fs = Arc::new(RwLock::new(create_rails_app_fs()));
+                let paths: Vec<Vec<&'static OsStr>> = vec![
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb")],
+                    vec![OsStr::new("app"), OsStr::new("controllers"), OsStr::new("controller0.rb")],
+                    vec![OsStr::new("config"), OsStr::new("routes.rb")],
+                    vec![
+                        OsStr::new("vendor"), OsStr::new("bundle"), OsStr::new("ruby"),
+                        OsStr::new("3.2.0"), OsStr::new("gems"), OsStr::new("rails"),
+                        OsStr::new("lib"), OsStr::new("rails0.rb"),
+                    ],
+                ];
+                let paths = Arc::new(paths);
+
+                b.iter(|| {
+                    let handles: Vec<_> = (0..num_threads)
+                        .map(|i| {
+                            let fs = Arc::clone(&fs);
+                            let paths = Arc::clone(&paths);
+                            thread::spawn(move || {
+                                let path = &paths[i % paths.len()];
+                                let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+                                // RwLock: read lock allows parallel reads
+                                let fs = fs.read().unwrap();
+                                fs.stat(black_box(path), &mut stat_buf)
+                            })
+                        })
+                        .collect();
+
+                    for handle in handles {
+                        handle.join().unwrap();
+                    }
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark concurrent require with RwLock
+/// Simulates: stat (read) -> open (write) -> read (write) -> close (write)
+fn bench_rwlock_require(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rwlock_require");
+
+    for num_threads in [1, 2, 4, 8] {
+        // Mutex baseline
+        group.bench_with_input(
+            BenchmarkId::new("mutex", num_threads),
+            &num_threads,
+            |b, &num_threads| {
+                let fs = Arc::new(Mutex::new(create_rails_app_fs()));
+                let paths: Vec<Vec<&'static OsStr>> = vec![
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb")],
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model1.rb")],
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model2.rb")],
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model3.rb")],
+                ];
+                let paths = Arc::new(paths);
+
+                b.iter(|| {
+                    let handles: Vec<_> = (0..num_threads)
+                        .map(|i| {
+                            let fs = Arc::clone(&fs);
+                            let paths = Arc::clone(&paths);
+                            thread::spawn(move || {
+                                let path = &paths[i % paths.len()];
+
+                                // stat
+                                {
+                                    let fs = fs.lock().unwrap();
+                                    let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+                                    fs.stat(black_box(path), &mut stat_buf);
+                                }
+
+                                // open
+                                let fd = {
+                                    let fs = fs.lock().unwrap();
+                                    fs.open(path).unwrap()
+                                };
+
+                                // read
+                                {
+                                    let fs = fs.lock().unwrap();
+                                    let mut buf = [0u8; 8192];
+                                    while fs.read(fd, &mut buf).unwrap_or(0) > 0 {}
+                                }
+
+                                // close
+                                {
+                                    let fs = fs.lock().unwrap();
+                                    fs.close(fd);
+                                }
+                                unsafe { libc::close(fd) };
+                            })
+                        })
+                        .collect();
+
+                    for handle in handles {
+                        handle.join().unwrap();
+                    }
+                })
+            },
+        );
+
+        // RwLock
+        group.bench_with_input(
+            BenchmarkId::new("rwlock", num_threads),
+            &num_threads,
+            |b, &num_threads| {
+                let fs = Arc::new(RwLock::new(create_rails_app_fs()));
+                let paths: Vec<Vec<&'static OsStr>> = vec![
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb")],
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model1.rb")],
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model2.rb")],
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model3.rb")],
+                ];
+                let paths = Arc::new(paths);
+
+                b.iter(|| {
+                    let handles: Vec<_> = (0..num_threads)
+                        .map(|i| {
+                            let fs = Arc::clone(&fs);
+                            let paths = Arc::clone(&paths);
+                            thread::spawn(move || {
+                                let path = &paths[i % paths.len()];
+
+                                // stat (read lock)
+                                {
+                                    let fs = fs.read().unwrap();
+                                    let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+                                    fs.stat(black_box(path), &mut stat_buf);
+                                }
+
+                                // open (write lock)
+                                let fd = {
+                                    let fs = fs.write().unwrap();
+                                    fs.open(path).unwrap()
+                                };
+
+                                // read (write lock)
+                                {
+                                    let fs = fs.write().unwrap();
+                                    let mut buf = [0u8; 8192];
+                                    while fs.read(fd, &mut buf).unwrap_or(0) > 0 {}
+                                }
+
+                                // close (write lock)
+                                {
+                                    let fs = fs.write().unwrap();
+                                    fs.close(fd);
+                                }
+                                unsafe { libc::close(fd) };
+                            })
+                        })
+                        .collect();
+
+                    for handle in handles {
+                        handle.join().unwrap();
+                    }
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark read-heavy workload (many stat calls vs few require calls)
+/// This is where RwLock should shine: many readers can proceed in parallel
+fn bench_rwlock_read_heavy(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rwlock_read_heavy");
+
+    // 8 threads: 7 doing stat (read), 1 doing require (write)
+    let num_threads = 8;
+    let stat_threads = 7;
+
+    group.bench_function("mutex", |b| {
+        let fs = Arc::new(Mutex::new(create_rails_app_fs()));
+        let stat_path: Vec<&'static OsStr> = vec![
+            OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb"),
+        ];
+        let require_path: Vec<&'static OsStr> = vec![
+            OsStr::new("app"), OsStr::new("controllers"), OsStr::new("controller0.rb"),
+        ];
+        let stat_path = Arc::new(stat_path);
+        let require_path = Arc::new(require_path);
+
+        b.iter(|| {
+            let handles: Vec<_> = (0..num_threads)
+                .map(|i| {
+                    let fs = Arc::clone(&fs);
+                    let stat_path = Arc::clone(&stat_path);
+                    let require_path = Arc::clone(&require_path);
+
+                    thread::spawn(move || {
+                        if i < stat_threads {
+                            // stat-only threads (read-heavy)
+                            for _ in 0..20 {
+                                let fs = fs.lock().unwrap();
+                                let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+                                fs.stat(black_box(&stat_path), &mut stat_buf);
+                            }
+                        } else {
+                            // require thread (write)
+                            let fd = {
+                                let fs = fs.lock().unwrap();
+                                fs.open(&require_path).unwrap()
+                            };
+
+                            {
+                                let fs = fs.lock().unwrap();
+                                let mut buf = [0u8; 8192];
+                                while fs.read(fd, &mut buf).unwrap_or(0) > 0 {}
+                            }
+
+                            {
+                                let fs = fs.lock().unwrap();
+                                fs.close(fd);
+                            }
+                            unsafe { libc::close(fd) };
+                        }
+                    })
+                })
+                .collect();
+
+            for handle in handles {
+                handle.join().unwrap();
+            }
+        })
+    });
+
+    group.bench_function("rwlock", |b| {
+        let fs = Arc::new(RwLock::new(create_rails_app_fs()));
+        let stat_path: Vec<&'static OsStr> = vec![
+            OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb"),
+        ];
+        let require_path: Vec<&'static OsStr> = vec![
+            OsStr::new("app"), OsStr::new("controllers"), OsStr::new("controller0.rb"),
+        ];
+        let stat_path = Arc::new(stat_path);
+        let require_path = Arc::new(require_path);
+
+        b.iter(|| {
+            let handles: Vec<_> = (0..num_threads)
+                .map(|i| {
+                    let fs = Arc::clone(&fs);
+                    let stat_path = Arc::clone(&stat_path);
+                    let require_path = Arc::clone(&require_path);
+
+                    thread::spawn(move || {
+                        if i < stat_threads {
+                            // stat-only threads (read lock - can run in parallel)
+                            for _ in 0..20 {
+                                let fs = fs.read().unwrap();
+                                let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+                                fs.stat(black_box(&stat_path), &mut stat_buf);
+                            }
+                        } else {
+                            // require thread (write lock)
+                            let fd = {
+                                let fs = fs.write().unwrap();
+                                fs.open(&require_path).unwrap()
+                            };
+
+                            {
+                                let fs = fs.write().unwrap();
+                                let mut buf = [0u8; 8192];
+                                while fs.read(fd, &mut buf).unwrap_or(0) > 0 {}
+                            }
+
+                            {
+                                let fs = fs.write().unwrap();
+                                fs.close(fd);
+                            }
+                            unsafe { libc::close(fd) };
+                        }
+                    })
+                })
+                .collect();
+
+            for handle in handles {
+                handle.join().unwrap();
+            }
+        })
+    });
+
+    group.finish();
+}
+
+/// Benchmark internal RwLock: Arc<Fs> without external lock
+/// This tests the internal RwLock implementation directly
+fn bench_internal_rwlock(c: &mut Criterion) {
+    let mut group = c.benchmark_group("internal_rwlock");
+
+    for num_threads in [2, 4, 8, 16] {
+        // External Mutex (baseline - old approach)
+        group.bench_with_input(
+            BenchmarkId::new("external_mutex_stat", num_threads),
+            &num_threads,
+            |b, &num_threads| {
+                let fs = Arc::new(Mutex::new(create_rails_app_fs()));
+                let path: Vec<&'static OsStr> = vec![
+                    OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb"),
+                ];
+                let path = Arc::new(path);
+
+                b.iter(|| {
+                    let handles: Vec<_> = (0..num_threads)
+                        .map(|_| {
+                            let fs = Arc::clone(&fs);
+                            let path = Arc::clone(&path);
+                            thread::spawn(move || {
+                                for _ in 0..10 {
+                                    let fs = fs.lock().unwrap();
+                                    let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+                                    fs.stat(black_box(&path), &mut stat_buf);
+                                }
+                            })
+                        })
+                        .collect();
+
+                    for handle in handles {
+                        handle.join().unwrap();
+                    }
+                })
+            },
+        );
+
+        // Internal RwLock only (new approach - no external lock for stat)
+        // stat only accesses trie, no lock needed
+        group.bench_with_input(
+            BenchmarkId::new("internal_only_stat", num_threads),
+            &num_threads,
+            |b, &num_threads| {
+                let fs = Arc::new(create_rails_app_fs());
+                let path: Vec<&'static OsStr> = vec![
+                    OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb"),
+                ];
+                let path = Arc::new(path);
+
+                b.iter(|| {
+                    let handles: Vec<_> = (0..num_threads)
+                        .map(|_| {
+                            let fs = Arc::clone(&fs);
+                            let path = Arc::clone(&path);
+                            thread::spawn(move || {
+                                for _ in 0..10 {
+                                    // No external lock needed - stat is lock-free (trie only)
+                                    let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+                                    fs.stat(black_box(&path), &mut stat_buf);
+                                }
+                            })
+                        })
+                        .collect();
+
+                    for handle in handles {
+                        handle.join().unwrap();
+                    }
+                })
+            },
+        );
+
+        // Require cycle: external mutex vs internal rwlock
+        group.bench_with_input(
+            BenchmarkId::new("external_mutex_require", num_threads),
+            &num_threads,
+            |b, &num_threads| {
+                let fs = Arc::new(Mutex::new(create_rails_app_fs()));
+                let paths: Vec<Vec<&'static OsStr>> = vec![
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb")],
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model1.rb")],
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model2.rb")],
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model3.rb")],
+                ];
+                let paths = Arc::new(paths);
+
+                b.iter(|| {
+                    let handles: Vec<_> = (0..num_threads)
+                        .map(|i| {
+                            let fs = Arc::clone(&fs);
+                            let paths = Arc::clone(&paths);
+                            thread::spawn(move || {
+                                let path = &paths[i % paths.len()];
+                                let fs = fs.lock().unwrap();
+
+                                // stat -> open -> read -> close (all under single lock)
+                                let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+                                fs.stat(black_box(path), &mut stat_buf);
+
+                                let fd = fs.open(path).unwrap();
+                                let mut buf = [0u8; 8192];
+                                while fs.read(fd, &mut buf).unwrap_or(0) > 0 {}
+                                fs.close(fd);
+                                unsafe { libc::close(fd) };
+                            })
+                        })
+                        .collect();
+
+                    for handle in handles {
+                        handle.join().unwrap();
+                    }
+                })
+            },
+        );
+
+        // Internal RwLock: no external lock, internal RwLock handles fd_map
+        group.bench_with_input(
+            BenchmarkId::new("internal_only_require", num_threads),
+            &num_threads,
+            |b, &num_threads| {
+                let fs = Arc::new(create_rails_app_fs());
+                let paths: Vec<Vec<&'static OsStr>> = vec![
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb")],
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model1.rb")],
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model2.rb")],
+                    vec![OsStr::new("app"), OsStr::new("models"), OsStr::new("model3.rb")],
+                ];
+                let paths = Arc::new(paths);
+
+                b.iter(|| {
+                    let handles: Vec<_> = (0..num_threads)
+                        .map(|i| {
+                            let fs = Arc::clone(&fs);
+                            let paths = Arc::clone(&paths);
+                            thread::spawn(move || {
+                                let path = &paths[i % paths.len()];
+
+                                // No external lock - internal RwLock handles concurrency
+                                let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+                                fs.stat(black_box(path), &mut stat_buf);
+
+                                let fd = fs.open(path).unwrap();
+                                let mut buf = [0u8; 8192];
+                                while fs.read(fd, &mut buf).unwrap_or(0) > 0 {}
+                                fs.close(fd);
+                                unsafe { libc::close(fd) };
+                            })
+                        })
+                        .collect();
+
+                    for handle in handles {
+                        handle.join().unwrap();
+                    }
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark pure stat workload (100% read operations)
+/// This is the best case for RwLock: all threads can read in parallel
+fn bench_rwlock_stat_only(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rwlock_stat_only");
+
+    for num_threads in [2, 4, 8, 16] {
+        // Mutex: all threads contend for exclusive lock
+        group.bench_with_input(
+            BenchmarkId::new("mutex", num_threads),
+            &num_threads,
+            |b, &num_threads| {
+                let fs = Arc::new(Mutex::new(create_rails_app_fs()));
+                let path: Vec<&'static OsStr> = vec![
+                    OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb"),
+                ];
+                let path = Arc::new(path);
+
+                b.iter(|| {
+                    let handles: Vec<_> = (0..num_threads)
+                        .map(|_| {
+                            let fs = Arc::clone(&fs);
+                            let path = Arc::clone(&path);
+                            thread::spawn(move || {
+                                for _ in 0..10 {
+                                    let fs = fs.lock().unwrap();
+                                    let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+                                    fs.stat(black_box(&path), &mut stat_buf);
+                                }
+                            })
+                        })
+                        .collect();
+
+                    for handle in handles {
+                        handle.join().unwrap();
+                    }
+                })
+            },
+        );
+
+        // RwLock: all threads can read in parallel
+        group.bench_with_input(
+            BenchmarkId::new("rwlock", num_threads),
+            &num_threads,
+            |b, &num_threads| {
+                let fs = Arc::new(RwLock::new(create_rails_app_fs()));
+                let path: Vec<&'static OsStr> = vec![
+                    OsStr::new("app"), OsStr::new("models"), OsStr::new("model0.rb"),
+                ];
+                let path = Arc::new(path);
+
+                b.iter(|| {
+                    let handles: Vec<_> = (0..num_threads)
+                        .map(|_| {
+                            let fs = Arc::clone(&fs);
+                            let path = Arc::clone(&path);
+                            thread::spawn(move || {
+                                for _ in 0..10 {
+                                    let fs = fs.read().unwrap();
+                                    let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+                                    fs.stat(black_box(&path), &mut stat_buf);
+                                }
+                            })
+                        })
+                        .collect();
+
+                    for handle in handles {
+                        handle.join().unwrap();
+                    }
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_require_simulation,
+    bench_dir_glob_simulation,
+    bench_read_by_size,
+    bench_stat_by_depth,
+    bench_scalability,
+    bench_basic_operations,
+    bench_concurrent_stat,
+    bench_concurrent_require,
+    bench_concurrent_mixed_workload,
+    bench_lock_contention,
+    // RwLock vs Mutex comparison benchmarks
+    bench_rwlock_stat,
+    bench_rwlock_require,
+    bench_rwlock_read_heavy,
+    bench_rwlock_stat_only,
+    // Internal RwLock benchmarks (Arc<Fs> without external lock)
+    bench_internal_rwlock,
+);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

- Replace external `Arc<Mutex<Fs>>` wrapper with internal `RwLock<HashMap>` for `fd_map` to improve concurrent access performance
- Change Fs methods from `&mut self` to `&self` enabling lock-free access to trie operations
- Use `libc::dup(0)` for thread-safe fd allocation from OS

## Benchmark Results

| Operation | Threads | Improvement |
|-----------|---------|-------------|
| stat | 16 | ~60% |
| require cycle | 16 | ~23% |

## Test plan

- [x] All unit tests pass (31 for kompo_storage, 34 for kompo_fs)
- [x] Rails application builds and runs successfully with the new implementation
- [x] Verified Rails server responds correctly on port 3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)