### PR TITLE
feat: add zlib compression support for embedded files

### DIFF
--- a/kompo_fs/build.rs
+++ b/kompo_fs/build.rs
@@ -19,4 +19,10 @@ fn main() {
 
     // Rerun if Cargo.toml changes
     println!("cargo:rerun-if-changed=Cargo.toml");
+
+    // Link zlib for compression support
+    // On macOS, zlib is available as a system library
+    // On Linux, it's typically available as libz
+    // In the final binary, this will use Ruby's statically linked zlib
+    println!("cargo:rustc-link-lib=z");
 }

--- a/kompo_fs/kompo_fs_test_data/dummy_fs.c
+++ b/kompo_fs/kompo_fs_test_data/dummy_fs.c
@@ -12,3 +12,12 @@ const unsigned long long FILES_SIZES[] = {0, 13, 25};
 
 // Working directory
 const char WD[] = "/test";
+
+// Compression support symbols (compression disabled for tests)
+const int COMPRESSION_ENABLED = 0;
+const char COMPRESSED_FILES[] = "";
+const int COMPRESSED_FILES_SIZE = 0;
+const unsigned long long COMPRESSED_SIZES[] = {0};
+char FILES_BUFFER[1] = {0};
+const int FILES_BUFFER_SIZE = 0;
+const unsigned long long ORIGINAL_SIZES[] = {0};


### PR DESCRIPTION
## Summary

- Add zlib compression support for embedded files to reduce binary size
- Decompress compressed file data at runtime using zlib's `uncompress()` function
- No additional crate dependencies - uses zlib linked via Ruby's zlib

## Changes

### New extern symbols
- `COMPRESSION_ENABLED` - flag to indicate if compression is enabled
- `COMPRESSED_FILES` / `COMPRESSED_FILES_SIZE` - compressed file data
- `FILES_BUFFER` / `FILES_BUFFER_SIZE` - decompression buffer (.bss section)
- `ORIGINAL_SIZES` - file offsets in decompressed data

### New functions
- `decompress_all_files()` - decompresses all files using zlib FFI
- Modified `initialize_fs()` - handles both compressed and uncompressed data

## Test plan
- [x] All kompo_fs tests pass (34 tests)
- [x] Clippy and format checks pass
- [x] Tested with kompo using `--compress` option
- [x] Verified binary size reduction: 59MB → 32MB (~46% reduction)

## Notes

This PR works in conjunction with kompo's `--compress` option. When compression is disabled (default), the code falls back to the original uncompressed data path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)