### PR TITLE
feat: add kompo_tree, a flat-arena path index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,12 @@ jobs:
       run: cargo build --verbose
 
     - name: Run tests
-      run: cargo test -p kompo_storage -p kompo_fs --verbose
+      run: cargo test -p kompo_storage -p kompo_fs -p kompo_tree --verbose
 
     - name: Check formatting
       run: cargo fmt -- --check
 
     - name: Run clippy
-      run: cargo clippy -p kompo_storage --no-deps -- -D warnings
+      run: |
+        cargo clippy -p kompo_storage --no-deps -- -D warnings
+        cargo clippy -p kompo_tree --all-targets --no-deps -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,12 +299,10 @@ version = "0.6.0"
 dependencies = [
  "errno",
  "kompo_fs_test_data",
- "kompo_storage",
+ "kompo_tree",
  "kompo_wrap",
  "libc",
- "rustc-hash",
  "serial_test",
- "trie-rs",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kompo_tree"
+version = "0.6.0"
+dependencies = [
+ "criterion",
+ "kompo_storage",
+ "libc",
+ "rustc-hash",
+ "trie-rs",
+]
+
+[[package]]
 name = "kompo_wrap"
 version = "0.6.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 [workspace]
 
-members = ["kompo_fs", "kompo_storage", "kompo_wrap", "kompo_fs/kompo_fs_test_data"]
+members = [
+    "kompo_fs",
+    "kompo_storage",
+    "kompo_tree",
+    "kompo_wrap",
+    "kompo_fs/kompo_fs_test_data",
+]
 resolver = "2"
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -8,17 +8,13 @@ kompo-vfs consists of three main components:
 
 | Crate | Description |
 |-------|-------------|
-| `kompo_fs` | Core virtual filesystem implementation using a trie data structure for efficient path lookup |
-| `kompo_storage` | Storage layer that manages file data and directory entries |
+| `kompo_fs` | Core virtual filesystem: the interposed libc entry points and the Ruby bindings |
+| `kompo_tree` | Path index and file table over the embedded data |
 | `kompo_wrap` | System call wrapper that intercepts and redirects filesystem operations |
 
-Plus one crate that is not wired into the binary yet:
+`kompo_storage` is the previous trie-based index. Nothing links it any more; it is kept so `cargo bench -p kompo_tree` can measure the two side by side on the same image.
 
-| Crate | Description |
-|-------|-------------|
-| `kompo_tree` | Flat-arena replacement for `kompo_storage`'s trie. Same operations, not yet used by `kompo_fs` |
-
-`kompo_tree` exists because path lookup through the trie costs more than the real filesystem it replaces. It indexes whole paths in one hash and gives each directory a contiguous range of entries, so `readdir` neither searches nor allocates. `cargo bench -p kompo_tree` runs both side by side on the same image.
+`kompo_tree` replaced it because path lookup through the trie cost more than the real filesystem it stands in for. It indexes whole paths in one hash and gives each directory a contiguous range of entries, so `readdir` neither searches nor allocates. Paths are handled as bytes end to end, which also means a filename that is not valid UTF-8 is looked up rather than panicked on.
 
 ### How It Works
 
@@ -81,16 +77,18 @@ $ cargo test -p kompo_storage -p kompo_fs
 kompo-vfs/
 ├── kompo_fs/           # Core VFS implementation
 │   └── src/
-│       └── lib.rs      # Trie-based filesystem, Ruby bindings
-├── kompo_storage/      # Storage layer
-│   └── src/
-│       └── lib.rs      # File/directory data management
-├── kompo_tree/         # Flat-arena path index (not yet wired in)
+│       ├── lib.rs      # Startup, Ruby bindings
+│       ├── glue.rs     # Interposed libc entry points
+│       └── util.rs     # Path resolution
+├── kompo_tree/         # Path index and file table
 │   ├── src/
 │   │   ├── lib.rs      # Fs API: open, read, stat, readdir
 │   │   └── tree.rs     # Node arena and path resolution
 │   └── benches/
 │       └── tree_bench.rs # A/B against kompo_storage
+├── kompo_storage/      # Previous trie index, kept for the benchmark
+│   └── src/
+│       └── lib.rs      # File/directory data management
 ├── kompo_wrap/         # System call wrappers
 │   └── src/
 │       └── lib.rs      # Intercepts open, read, stat, etc.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ kompo-vfs consists of three main components:
 | `kompo_storage` | Storage layer that manages file data and directory entries |
 | `kompo_wrap` | System call wrapper that intercepts and redirects filesystem operations |
 
+Plus one crate that is not wired into the binary yet:
+
+| Crate | Description |
+|-------|-------------|
+| `kompo_tree` | Flat-arena replacement for `kompo_storage`'s trie. Same operations, not yet used by `kompo_fs` |
+
+`kompo_tree` exists because path lookup through the trie costs more than the real filesystem it replaces. It indexes whole paths in one hash and gives each directory a contiguous range of entries, so `readdir` neither searches nor allocates. `cargo bench -p kompo_tree` runs both side by side on the same image.
+
 ### How It Works
 
 kompo-vfs hooks into system calls (`open`, `read`, `stat`, `opendir`, etc.) to transparently redirect file operations. When the packed binary runs:
@@ -77,6 +85,12 @@ kompo-vfs/
 ├── kompo_storage/      # Storage layer
 │   └── src/
 │       └── lib.rs      # File/directory data management
+├── kompo_tree/         # Flat-arena path index (not yet wired in)
+│   ├── src/
+│   │   ├── lib.rs      # Fs API: open, read, stat, readdir
+│   │   └── tree.rs     # Node arena and path resolution
+│   └── benches/
+│       └── tree_bench.rs # A/B against kompo_storage
 ├── kompo_wrap/         # System call wrappers
 │   └── src/
 │       └── lib.rs      # Intercepts open, read, stat, etc.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This library is designed to be used with the [kompo](https://github.com/ahogappa
 ### Running Tests
 
 ```sh
-$ cargo test -p kompo_storage -p kompo_fs
+$ cargo test -p kompo_storage -p kompo_fs -p kompo_tree
 ```
 
 ### Project Structure

--- a/kompo_fs/Cargo.toml
+++ b/kompo_fs/Cargo.toml
@@ -9,9 +9,7 @@ crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 libc = "0.2.169"
-trie-rs = "0.4.2"
-rustc-hash = "2"
-kompo_storage = { path = "../kompo_storage" }
+kompo_tree = { path = "../kompo_tree" }
 kompo_wrap = { path = "../kompo_wrap" } 
 errno = "*"
 

--- a/kompo_fs/src/glue.rs
+++ b/kompo_fs/src/glue.rs
@@ -55,7 +55,6 @@ pub fn mmap_from_fs(
     }
 }
 
-/// Open a path that has already been resolved into the image.
 fn open_resolved(path: &[u8], oflag: libc::c_int) -> i32 {
     let fs = fs();
     let Some(node) = fs.lookup(path) else {

--- a/kompo_fs/src/glue.rs
+++ b/kompo_fs/src/glue.rs
@@ -62,7 +62,7 @@ fn open_resolved(path: &[u8], oflag: libc::c_int) -> i32 {
         return enoent();
     };
 
-    if oflag & libc::O_DIRECTORY == libc::O_DIRECTORY && !fs.tree().is_dir(node) {
+    if oflag & libc::O_DIRECTORY == libc::O_DIRECTORY && !fs.is_dir(node) {
         errno::set_errno(errno::Errno(libc::ENOTDIR));
         return -1;
     }
@@ -101,18 +101,7 @@ pub unsafe fn openat_from_fs(
 
     let raw = unsafe { util::path_bytes(pathname) };
 
-    // A relative name is only ours when it resolves against the working
-    // directory, which is what AT_FDCWD asks for; any other dirfd names a
-    // directory in the real filesystem.
-    let resolved = if raw.first() == Some(&b'/') {
-        util::is_under_kompo_working_dir(raw).then_some(Cow::Borrowed(raw))
-    } else if dirfd == libc::AT_FDCWD {
-        util::kompo_path(raw)
-    } else {
-        None
-    };
-
-    match resolved {
+    match util::kompo_path_at(dirfd, raw) {
         Some(resolved) => open_resolved(&resolved, flags),
         None => unsafe { kompo_wrap::OPENAT_HANDLE(dirfd, pathname, flags, mode) },
     }
@@ -171,15 +160,7 @@ pub unsafe fn fstatat_from_fs(
 ) -> i32 {
     let raw = unsafe { util::path_bytes(pathname) };
 
-    let resolved = if raw.first() == Some(&b'/') {
-        util::is_under_kompo_working_dir(raw).then_some(Cow::Borrowed(raw))
-    } else if dirfd == libc::AT_FDCWD {
-        util::kompo_path(raw)
-    } else {
-        None
-    };
-
-    match resolved {
+    match util::kompo_path_at(dirfd, raw) {
         Some(resolved) => stat_resolved(&resolved, buf),
         None => unsafe { kompo_wrap::FSTATAT_HANDLE(dirfd, pathname, buf, flags) },
     }
@@ -273,13 +254,12 @@ pub fn readdir_from_fs(dir: *mut libc::DIR) -> *mut libc::dirent {
         return unsafe { kompo_wrap::READDIR_HANDLE(dir) };
     }
 
-    let mut handle = unsafe { Box::from_raw(dir as *mut kompo_tree::FsDir) };
-    // The entry points into `handle`, which outlives this call and is only
-    // rewritten by the next readdir -- the same contract as readdir(3).
-    let entry = fs().readdir(&mut handle).unwrap_or(std::ptr::null_mut());
-    let _ = Box::into_raw(handle);
+    // The DIR* stays the caller's until closedir, so borrow it. The entry
+    // points into it and is only rewritten by the next readdir -- the same
+    // contract as readdir(3).
+    let handle = unsafe { &mut *(dir as *mut kompo_tree::FsDir) };
 
-    entry
+    fs().readdir(handle).unwrap_or(std::ptr::null_mut())
 }
 
 #[unsafe(no_mangle)]
@@ -315,9 +295,8 @@ pub fn rewinddir_from_fs(dir: *mut libc::DIR) {
         return;
     }
 
-    let mut handle = unsafe { Box::from_raw(dir as *mut kompo_tree::FsDir) };
-    fs().rewinddir(&mut handle);
-    let _ = Box::into_raw(handle);
+    let handle = unsafe { &mut *(dir as *mut kompo_tree::FsDir) };
+    fs().rewinddir(handle);
 }
 
 /// # Safety
@@ -334,9 +313,13 @@ pub unsafe extern "C-unwind" fn realpath_from_fs(
         return unsafe { kompo_wrap::REALPATH_HANDLE(path, resolved_path) };
     };
 
-    // An absolute argument reaches us spelled however the caller wrote it, so
-    // normalise before answering: realpath(3) promises a canonical path.
-    let canonical = util::join_normalized(b"/", &resolved);
+    // realpath(3) promises a canonical path. A relative argument was already
+    // normalised against the working directory on the way in; an absolute one
+    // reaches us spelled however the caller wrote it.
+    let canonical = match resolved {
+        Cow::Owned(path) => path,
+        Cow::Borrowed(path) => util::join_normalized(b"/", path),
+    };
     let canonical = CString::new(canonical).expect("path contains a null byte");
 
     if resolved_path.is_null() {

--- a/kompo_fs/src/glue.rs
+++ b/kompo_fs/src/glue.rs
@@ -334,7 +334,10 @@ pub unsafe extern "C-unwind" fn realpath_from_fs(
         return unsafe { kompo_wrap::REALPATH_HANDLE(path, resolved_path) };
     };
 
-    let canonical = CString::new(resolved.into_owned()).expect("path contains a null byte");
+    // An absolute argument reaches us spelled however the caller wrote it, so
+    // normalise before answering: realpath(3) promises a canonical path.
+    let canonical = util::join_normalized(b"/", &resolved);
+    let canonical = CString::new(canonical).expect("path contains a null byte");
 
     if resolved_path.is_null() {
         // The caller frees this, matching realpath(path, NULL).

--- a/kompo_fs/src/glue.rs
+++ b/kompo_fs/src/glue.rs
@@ -1,10 +1,23 @@
-use std::{
-    ffi::{CStr, CString},
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+//! Interposed libc entry points.
+//!
+//! Each one decides whether the path belongs to the packed image and either
+//! answers it from [`crate::fs`] or hands the original arguments to the real
+//! libc function.
+//!
+//! Paths are handled as bytes throughout. The previous version went through
+//! `CStr::to_str()`, which validates UTF-8 on every intercepted call and panics
+//! on a filename that is not valid UTF-8 -- a Latin-1 name inside a gem is
+//! enough, since nothing validates encoding when the image is built.
 
-use crate::{FILE_TYPE_CACHE, TRIE, WORKING_DIR, initialize_trie, util};
+use std::borrow::Cow;
+use std::ffi::CString;
+
+use crate::{WORKING_DIR, fs, util};
+
+fn enoent() -> i32 {
+    errno::set_errno(errno::Errno(libc::ENOENT));
+    -1
+}
 
 #[unsafe(no_mangle)]
 pub fn mmap_from_fs(
@@ -15,89 +28,60 @@ pub fn mmap_from_fs(
     fd: libc::c_int,
     offset: libc::off_t,
 ) -> *mut libc::c_void {
-    if fd == -1 {
+    if fd == -1 || !util::is_fd_exists_in_kompo(fd) {
         return unsafe { kompo_wrap::MMAP_HANDLE(addr, length, prot, flags, fd, offset) };
     }
 
-    if util::is_fd_exists_in_kompo(fd) {
-        let mm = unsafe {
-            kompo_wrap::MMAP_HANDLE(
-                addr,
-                length,
-                libc::PROT_READ | libc::PROT_WRITE, // write by read_from_fs()
-                libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
-                -1,
-                offset,
-            )
-        };
+    let mm = unsafe {
+        kompo_wrap::MMAP_HANDLE(
+            addr,
+            length,
+            libc::PROT_READ | libc::PROT_WRITE, // write by read_from_fs()
+            libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
+            -1,
+            offset,
+        )
+    };
 
-        if mm == libc::MAP_FAILED {
-            return mm;
-        }
-
-        if read_from_fs(fd, mm, length) >= 0 {
-            mm
-        } else {
-            errno::set_errno(errno::Errno(libc::EBADF));
-            libc::MAP_FAILED
-        }
-    } else {
-        unsafe { kompo_wrap::MMAP_HANDLE(addr, length, prot, flags, fd, offset) }
+    if mm == libc::MAP_FAILED {
+        return mm;
     }
+
+    if read_from_fs(fd, mm, length) >= 0 {
+        mm
+    } else {
+        errno::set_errno(errno::Errno(libc::EBADF));
+        libc::MAP_FAILED
+    }
+}
+
+/// Open a path that has already been resolved into the image.
+fn open_resolved(path: &[u8], oflag: libc::c_int) -> i32 {
+    let fs = fs();
+    let Some(node) = fs.lookup(path) else {
+        return enoent();
+    };
+
+    if oflag & libc::O_DIRECTORY == libc::O_DIRECTORY && !fs.tree().is_dir(node) {
+        errno::set_errno(errno::Errno(libc::ENOTDIR));
+        return -1;
+    }
+
+    fs.open_node(node).unwrap_or_else(enoent)
 }
 
 #[unsafe(no_mangle)]
 pub fn open_from_fs(path: *const libc::c_char, oflag: libc::c_int, mode: libc::mode_t) -> i32 {
-    fn inner_open(path: *const libc::c_char, oflag: libc::c_int) -> libc::c_int {
-        let path_cstr = unsafe { CStr::from_ptr(path) };
-        let path_obj = Path::new(path_cstr.to_str().expect("invalid path"));
-        let path_vec = path_obj.iter().collect::<Vec<_>>();
+    let raw = unsafe { util::path_bytes(path) };
 
-        let trie = std::sync::Arc::clone(TRIE.get_or_init(initialize_trie));
-
-        #[cfg(target_os = "macos")]
-        let o_directory = libc::O_DIRECTORY;
-        #[cfg(target_os = "linux")]
-        let o_directory = libc::O_DIRECTORY;
-
-        if oflag & o_directory == o_directory {
-            let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
-            match trie.stat(&path_vec, &mut stat_buf) {
-                Some(_) => {
-                    if stat_buf.st_mode & libc::S_IFMT == libc::S_IFDIR {
-                        trie.open(&path_vec).unwrap_or_else(|| {
-                            errno::set_errno(errno::Errno(libc::ENOENT));
-                            -1
-                        })
-                    } else {
-                        errno::set_errno(errno::Errno(libc::ENOTDIR));
-                        -1
-                    }
-                }
-                None => {
-                    errno::set_errno(errno::Errno(libc::ENOENT));
-                    -1
-                }
-            }
-        } else {
-            trie.open(&path_vec).unwrap_or_else(|| {
-                errno::set_errno(errno::Errno(libc::ENOENT));
-                -1
-            })
-        }
-    }
-
-    if WORKING_DIR.read().unwrap().is_some() && unsafe { *path } != b'/'.try_into().unwrap() {
-        let expand_path = unsafe { util::expand_kompo_path(path) };
-
-        inner_open(expand_path, oflag)
-    } else if unsafe { util::is_under_kompo_working_dir(path) } {
-        inner_open(path, oflag)
-    } else {
-        unsafe { kompo_wrap::OPEN_HANDLE(path, oflag, mode) }
+    match util::kompo_path(raw) {
+        Some(resolved) => open_resolved(&resolved, oflag),
+        None => unsafe { kompo_wrap::OPEN_HANDLE(path, oflag, mode) },
     }
 }
 
+/// # Safety
+/// `pathname` must be a valid pointer to a null-terminated C string.
 #[unsafe(no_mangle)]
 pub unsafe fn openat_from_fs(
     dirfd: libc::c_int,
@@ -105,35 +89,9 @@ pub unsafe fn openat_from_fs(
     flags: libc::c_int,
     mode: libc::mode_t,
 ) -> libc::c_int {
-    fn inner_openat(
-        _dirfd: libc::c_int,
-        pathname: *const libc::c_char,
-        _flags: libc::c_int,
-        _mode: libc::mode_t,
-    ) -> libc::c_int {
-        let path = unsafe { CStr::from_ptr(pathname) };
-        let path = PathBuf::from_str(path.to_str().expect("invalid path")).unwrap();
-
-        let current_dir = WORKING_DIR.read().unwrap();
-        let current_dir = current_dir.clone().expect("not found current dir");
-        let mut current_dir = PathBuf::from(current_dir);
-
-        util::canonicalize_path(&mut current_dir, &path);
-
-        let path = current_dir.iter().collect::<Vec<_>>();
-
-        let trie = std::sync::Arc::clone(TRIE.get_or_init(initialize_trie));
-
-        trie.open(&path).unwrap_or_else(|| {
-            errno::set_errno(errno::Errno(libc::ENOENT));
-            -1
-        })
-    }
-
     #[cfg(target_os = "linux")]
     let is_create_flag =
         flags & libc::O_CREAT == libc::O_CREAT || flags & libc::O_TMPFILE == libc::O_TMPFILE;
-
     #[cfg(not(target_os = "linux"))]
     let is_create_flag = flags & libc::O_CREAT == libc::O_CREAT;
 
@@ -141,77 +99,69 @@ pub unsafe fn openat_from_fs(
         return unsafe { kompo_wrap::OPENAT_HANDLE(dirfd, pathname, flags, mode) };
     }
 
-    if unsafe { util::is_under_kompo_working_dir(pathname) } {
-        return open_from_fs(pathname, flags, mode);
-    }
+    let raw = unsafe { util::path_bytes(pathname) };
 
-    if dirfd == libc::AT_FDCWD
-        && WORKING_DIR.read().unwrap().is_some()
-        && unsafe { *pathname } != b'/'.try_into().unwrap()
-    {
-        return inner_openat(dirfd, pathname, flags, mode);
-    }
+    // A relative name is only ours when it resolves against the working
+    // directory, which is what AT_FDCWD asks for; any other dirfd names a
+    // directory in the real filesystem.
+    let resolved = if raw.first() == Some(&b'/') {
+        util::is_under_kompo_working_dir(raw).then_some(Cow::Borrowed(raw))
+    } else if dirfd == libc::AT_FDCWD {
+        util::kompo_path(raw)
+    } else {
+        None
+    };
 
-    unsafe { kompo_wrap::OPENAT_HANDLE(dirfd, pathname, flags, mode) }
+    match resolved {
+        Some(resolved) => open_resolved(&resolved, flags),
+        None => unsafe { kompo_wrap::OPENAT_HANDLE(dirfd, pathname, flags, mode) },
+    }
 }
 
 #[unsafe(no_mangle)]
 pub fn close_from_fs(fd: i32) -> i32 {
     if util::is_fd_exists_in_kompo(fd) {
-        std::sync::Arc::clone(TRIE.get_or_init(initialize_trie)).close(fd);
-    };
+        fs().close(fd);
+    }
 
-    unsafe { kompo_wrap::CLOSE_HANDLE(fd) } // kompo_fs' inner fd made by dup(). so, close it.
+    unsafe { kompo_wrap::CLOSE_HANDLE(fd) } // the inner fd came from dup(), so close it
+}
+
+fn stat_resolved(path: &[u8], stat: *mut libc::stat) -> i32 {
+    if stat.is_null() {
+        errno::set_errno(errno::Errno(libc::EFAULT));
+        return -1;
+    }
+
+    match fs().stat(path, unsafe { &mut *stat }) {
+        Some(_) => 0,
+        None => enoent(),
+    }
 }
 
 #[unsafe(no_mangle)]
 pub fn stat_from_fs(path: *const libc::c_char, stat: *mut libc::stat) -> i32 {
-    fn inner_stat(path: *const libc::c_char, stat: *mut libc::stat) -> i32 {
-        if stat.is_null() {
-            errno::set_errno(errno::Errno(libc::EFAULT));
-            return -1;
-        }
+    let raw = unsafe { util::path_bytes(path) };
 
-        let path = unsafe { CStr::from_ptr(path) };
-        let path = Path::new(path.to_str().expect("invalid path"));
-        let path = path
-            .iter()
-            .map(|os_str| os_str.to_os_string())
-            .collect::<Vec<_>>();
-
-        // TODO: move to trie.stat()
-        if let Some(cache) = FILE_TYPE_CACHE.read().unwrap().get(&path) {
-            unsafe { *stat = *cache };
-            return 0;
-        }
-
-        let sarch_path = path
-            .iter()
-            .map(|os_str| os_str.as_os_str())
-            .collect::<Vec<_>>();
-
-        let trie = std::sync::Arc::clone(TRIE.get_or_init(initialize_trie));
-        let ret = trie.stat(&sarch_path, unsafe { &mut *stat });
-        if ret.is_some() {
-            unsafe { FILE_TYPE_CACHE.write().unwrap().insert(path, *stat) };
-            0
-        } else {
-            errno::set_errno(errno::Errno(libc::ENOENT));
-            -1
-        }
-    }
-
-    if WORKING_DIR.read().unwrap().is_some() && unsafe { *path } != b'/'.try_into().unwrap() {
-        let expand_path = unsafe { util::expand_kompo_path(path) };
-
-        inner_stat(expand_path, stat)
-    } else if unsafe { util::is_under_kompo_working_dir(path) } {
-        inner_stat(path, stat)
-    } else {
-        unsafe { kompo_wrap::STAT_HANDLE(path, stat) }
+    match util::kompo_path(raw) {
+        Some(resolved) => stat_resolved(&resolved, stat),
+        None => unsafe { kompo_wrap::STAT_HANDLE(path, stat) },
     }
 }
 
+/// The image holds no symlinks, so this is `stat`.
+#[unsafe(no_mangle)]
+pub fn lstat_from_fs(path: *const libc::c_char, stat: *mut libc::stat) -> i32 {
+    let raw = unsafe { util::path_bytes(path) };
+
+    match util::kompo_path(raw) {
+        Some(resolved) => stat_resolved(&resolved, stat),
+        None => unsafe { kompo_wrap::LSTAT_HANDLE(path, stat) },
+    }
+}
+
+/// # Safety
+/// `pathname` must be a valid pointer to a null-terminated C string.
 #[unsafe(no_mangle)]
 pub unsafe fn fstatat_from_fs(
     dirfd: libc::c_int,
@@ -219,381 +169,205 @@ pub unsafe fn fstatat_from_fs(
     buf: *mut libc::stat,
     flags: libc::c_int,
 ) -> i32 {
-    fn inner_fstatat(
-        _dirfd: libc::c_int,
-        path: *const libc::c_char,
-        stat: *mut libc::stat,
-        _flags: libc::c_int,
-    ) -> i32 {
-        if stat.is_null() {
-            errno::set_errno(errno::Errno(libc::EFAULT));
-            return -1;
-        }
+    let raw = unsafe { util::path_bytes(pathname) };
 
-        let path = unsafe { CStr::from_ptr(path) };
-        let path = PathBuf::from_str(path.to_str().expect("invalid path")).expect("invalid path");
-
-        let current_dir = WORKING_DIR.read().unwrap();
-        let current_dir = current_dir.clone().expect("not found current dir");
-        let mut current_dir = PathBuf::from(current_dir);
-
-        util::canonicalize_path(&mut current_dir, &path);
-
-        let sarch_path = current_dir.iter().collect::<Vec<_>>();
-
-        let trie = std::sync::Arc::clone(TRIE.get_or_init(initialize_trie));
-        let ret = trie.stat(&sarch_path, unsafe { &mut *stat });
-        if ret.is_some() {
-            0
-        } else {
-            errno::set_errno(errno::Errno(libc::ENOENT));
-            -1
-        }
-    }
-
-    if unsafe { util::is_under_kompo_working_dir(pathname) } {
-        return stat_from_fs(pathname, buf);
-    }
-
-    if dirfd == libc::AT_FDCWD
-        && WORKING_DIR.read().unwrap().is_some()
-        && unsafe { *pathname } != b'/'.try_into().unwrap()
-    {
-        return inner_fstatat(dirfd, pathname, buf, flags);
-    }
-
-    unsafe { kompo_wrap::FSTATAT_HANDLE(dirfd, pathname, buf, flags) }
-}
-
-#[unsafe(no_mangle)]
-pub fn lstat_from_fs(path: *const libc::c_char, stat: *mut libc::stat) -> i32 {
-    fn inner_lstat(path: *const libc::c_char, stat: *mut libc::stat) -> i32 {
-        if stat.is_null() {
-            errno::set_errno(errno::Errno(libc::EFAULT));
-            return -1;
-        }
-
-        let path = unsafe { CStr::from_ptr(path) };
-        let path = Path::new(path.to_str().expect("invalid path"));
-        let path = path
-            .iter()
-            .map(|os_str| os_str.to_os_string())
-            .collect::<Vec<_>>();
-
-        // TODO: move to trie.stat()
-        if let Some(cache) = FILE_TYPE_CACHE.read().unwrap().get(&path) {
-            unsafe { *stat = *cache };
-            return 0;
-        }
-
-        let sarch_path = path
-            .iter()
-            .map(|os_str| os_str.as_os_str())
-            .collect::<Vec<_>>();
-
-        let trie = std::sync::Arc::clone(TRIE.get_or_init(initialize_trie));
-        let ret = trie.lstat(&sarch_path, unsafe { &mut *stat });
-        if ret.is_some() {
-            unsafe { FILE_TYPE_CACHE.write().unwrap().insert(path, *stat) };
-            0
-        } else {
-            errno::set_errno(errno::Errno(libc::ENOENT));
-            -1
-        }
-    }
-
-    if WORKING_DIR.read().unwrap().is_some() && unsafe { *path } != b'/'.try_into().unwrap() {
-        let expand_path = unsafe { util::expand_kompo_path(path) };
-
-        inner_lstat(expand_path, stat)
-    } else if unsafe { util::is_under_kompo_working_dir(path) } {
-        inner_lstat(path, stat)
+    let resolved = if raw.first() == Some(&b'/') {
+        util::is_under_kompo_working_dir(raw).then_some(Cow::Borrowed(raw))
+    } else if dirfd == libc::AT_FDCWD {
+        util::kompo_path(raw)
     } else {
-        unsafe { kompo_wrap::LSTAT_HANDLE(path, stat) }
+        None
+    };
+
+    match resolved {
+        Some(resolved) => stat_resolved(&resolved, buf),
+        None => unsafe { kompo_wrap::FSTATAT_HANDLE(dirfd, pathname, buf, flags) },
     }
 }
 
 #[unsafe(no_mangle)]
 pub fn fstat_from_fs(fd: i32, stat: *mut libc::stat) -> i32 {
-    fn inner_fstat(fd: i32, stat: *mut libc::stat) -> i32 {
-        if stat.is_null() {
-            errno::set_errno(errno::Errno(libc::EFAULT));
-            return -1;
-        }
-
-        let trie = std::sync::Arc::clone(TRIE.get_or_init(initialize_trie));
-        let ret = trie.fstat(fd, unsafe { &mut *stat });
-
-        if ret.is_some() {
-            0
-        } else {
-            errno::set_errno(errno::Errno(libc::ENOENT));
-            -1
-        }
+    if !util::is_fd_exists_in_kompo(fd) {
+        return unsafe { kompo_wrap::FSTAT_HANDLE(fd, stat) };
     }
 
-    if util::is_fd_exists_in_kompo(fd) {
-        inner_fstat(fd, stat)
-    } else {
-        unsafe { kompo_wrap::FSTAT_HANDLE(fd, stat) }
+    if stat.is_null() {
+        errno::set_errno(errno::Errno(libc::EFAULT));
+        return -1;
+    }
+
+    match fs().fstat(fd, unsafe { &mut *stat }) {
+        Some(_) => 0,
+        None => enoent(),
     }
 }
 
 #[unsafe(no_mangle)]
 pub fn read_from_fs(fd: i32, buf: *mut libc::c_void, count: libc::size_t) -> isize {
-    fn inner_read(fd: i32, buf: *mut libc::c_void, count: libc::size_t) -> isize {
-        let buf = unsafe { std::slice::from_raw_parts_mut(buf as *mut u8, count) };
-
-        let trie = std::sync::Arc::clone(TRIE.get_or_init(initialize_trie));
-        let ret = trie.read(fd, buf);
-
-        if let Some(read_bytes) = ret {
-            read_bytes
-        } else {
-            errno::set_errno(errno::Errno(libc::ENOENT));
-            -1
-        }
+    if !util::is_fd_exists_in_kompo(fd) {
+        return unsafe { kompo_wrap::READ_HANDLE(fd, buf, count) };
     }
 
-    if util::is_fd_exists_in_kompo(fd) {
-        inner_read(fd, buf, count)
-    } else {
-        unsafe { kompo_wrap::READ_HANDLE(fd, buf, count) }
+    let buf = unsafe { std::slice::from_raw_parts_mut(buf as *mut u8, count) };
+
+    match fs().read(fd, buf) {
+        Some(read_bytes) => read_bytes,
+        None => enoent() as isize,
     }
 }
 
 #[unsafe(no_mangle)]
 pub fn getcwd_from_fs(buf: *mut libc::c_char, count: libc::size_t) -> *const libc::c_char {
-    fn inner_getcwd(buf: *mut libc::c_char, count: libc::size_t) -> *const libc::c_char {
-        let working_dir = WORKING_DIR.read().unwrap();
+    let working_dir = WORKING_DIR.read().unwrap();
+    let Some(working_dir) = working_dir.as_deref() else {
+        return unsafe { kompo_wrap::GETCWD_HANDLE(buf, count) };
+    };
 
-        if working_dir.is_none() {
-            return std::ptr::null();
-        }
-
-        let working_dir = working_dir.clone().unwrap();
-
-        if buf.is_null() {
-            if count == 0 {
-                let working_directory_path =
-                    CString::new(working_dir.to_str().expect("invalid path"))
-                        .expect("invalid path")
-                        .into_boxed_c_str();
-                let ptr = Box::into_raw(working_directory_path);
-
-                ptr as *const libc::c_char
-            } else {
-                todo!()
-            }
-        } else {
-            todo!()
-        }
+    if !buf.is_null() || count != 0 {
+        todo!()
     }
 
-    if WORKING_DIR.read().unwrap().is_some() {
-        inner_getcwd(buf, count)
-    } else {
-        unsafe { kompo_wrap::GETCWD_HANDLE(buf, count) }
-    }
+    // The caller frees this, matching getcwd(NULL, 0).
+    CString::new(working_dir)
+        .expect("working directory contains a null byte")
+        .into_raw()
 }
 
 #[unsafe(no_mangle)]
 pub fn chdir_from_fs(path: *const libc::c_char) -> libc::c_int {
-    fn inner_chdir(path: *const libc::c_char) -> libc::c_int {
-        let path = unsafe { CStr::from_ptr(path) };
-        let path = Path::new(path.to_str().expect("invalid path"));
+    let raw = unsafe { util::path_bytes(path) };
 
-        let search_path = path.iter().collect::<Vec<_>>();
-        let trie = std::sync::Arc::clone(TRIE.get_or_init(initialize_trie));
-        let bool = trie.is_dir_exists_from_path(&search_path);
-
-        if bool {
-            let changed_path = path.as_os_str().to_os_string();
-            *WORKING_DIR.write().unwrap() = Some(changed_path);
-
-            1
-        } else {
-            -1
-        }
-    }
-
-    let change_dir = unsafe { util::expand_kompo_path(path) };
-
-    if unsafe { util::is_under_kompo_working_dir(change_dir) } {
-        inner_chdir(change_dir)
-    } else {
+    let Some(resolved) = util::kompo_path(raw) else {
         let ret = unsafe { kompo_wrap::CHDIR_HANDLE(path) };
         if ret == 0 {
+            // We left the image, so relative paths are the real filesystem's again.
             *WORKING_DIR.write().unwrap() = None;
         }
+        return ret;
+    };
 
-        ret
+    if !fs().is_dir_exists_from_path(&resolved) {
+        return -1;
     }
+
+    *WORKING_DIR.write().unwrap() = Some(resolved.into_owned());
+
+    1 // preserved from the previous implementation; chdir(2) returns 0
 }
 
 #[unsafe(no_mangle)]
 pub fn fdopendir_from_fs(fd: i32) -> *mut libc::DIR {
-    fn inner_fdopendir(fd: i32) -> *mut libc::DIR {
-        let trie = std::sync::Arc::clone(TRIE.get_or_init(initialize_trie));
-        match trie.fdopendir(fd) {
-            Some(dir) => {
-                let dir = Box::new(dir);
-                Box::into_raw(dir) as *mut libc::DIR
-            }
-            None => std::ptr::null_mut(),
-        }
+    if !util::is_fd_exists_in_kompo(fd) {
+        return unsafe { kompo_wrap::FDOPENDIR_HANDLE(fd) };
     }
 
-    if util::is_fd_exists_in_kompo(fd) {
-        inner_fdopendir(fd)
-    } else {
-        unsafe { kompo_wrap::FDOPENDIR_HANDLE(fd) }
+    match fs().fdopendir(fd) {
+        Some(dir) => Box::into_raw(Box::new(dir)) as *mut libc::DIR,
+        None => std::ptr::null_mut(),
     }
 }
 
 #[unsafe(no_mangle)]
 pub fn readdir_from_fs(dir: *mut libc::DIR) -> *mut libc::dirent {
-    fn inner_readdir(dir: *mut libc::DIR) -> *mut libc::dirent {
-        let mut dir = unsafe { Box::from_raw(dir as *mut kompo_storage::FsDir) };
-
-        let trie = std::sync::Arc::clone(TRIE.get_or_init(initialize_trie));
-        match trie.readdir(&mut dir) {
-            Some(dirent) => {
-                let _ = Box::into_raw(dir);
-                dirent
-            }
-            None => {
-                let _ = Box::into_raw(dir);
-                std::ptr::null_mut()
-            }
-        }
+    if !unsafe { util::is_dir_exists_in_kompo(dir) } {
+        return unsafe { kompo_wrap::READDIR_HANDLE(dir) };
     }
 
-    if unsafe { util::is_dir_exists_in_kompo(dir) } {
-        inner_readdir(dir)
-    } else {
-        unsafe { kompo_wrap::READDIR_HANDLE(dir) }
-    }
+    let mut handle = unsafe { Box::from_raw(dir as *mut kompo_tree::FsDir) };
+    // The entry points into `handle`, which outlives this call and is only
+    // rewritten by the next readdir -- the same contract as readdir(3).
+    let entry = fs().readdir(&mut handle).unwrap_or(std::ptr::null_mut());
+    let _ = Box::into_raw(handle);
+
+    entry
 }
 
 #[unsafe(no_mangle)]
 pub fn closedir_from_fs(dir: *mut libc::DIR) -> i32 {
-    if unsafe { util::is_dir_exists_in_kompo(dir) } {
-        let dir = unsafe { Box::from_raw(dir as *mut kompo_storage::FsDir) };
-        std::sync::Arc::clone(TRIE.get_or_init(initialize_trie)).closedir(&dir);
-
-        unsafe { kompo_wrap::CLOSE_HANDLE(dir.fd) }
-    } else {
-        unsafe { kompo_wrap::CLOSEDIR_HANDLE(dir) }
+    if !unsafe { util::is_dir_exists_in_kompo(dir) } {
+        return unsafe { kompo_wrap::CLOSEDIR_HANDLE(dir) };
     }
+
+    let handle = unsafe { Box::from_raw(dir as *mut kompo_tree::FsDir) };
+    fs().closedir(&handle);
+
+    unsafe { kompo_wrap::CLOSE_HANDLE(handle.fd) }
 }
 
 #[unsafe(no_mangle)]
 pub fn opendir_from_fs(path: *const libc::c_char) -> *mut libc::DIR {
-    fn inner_opendir(path: *const libc::c_char) -> *mut libc::DIR {
-        let path_cstr = unsafe { CStr::from_ptr(path) };
-        let path_str = path_cstr.to_str().expect("invalid path");
-        let path = Path::new(path_str);
-        let path = path.iter().collect::<Vec<_>>();
+    let raw = unsafe { util::path_bytes(path) };
 
-        let trie = std::sync::Arc::clone(TRIE.get_or_init(initialize_trie));
-        match trie.opendir(&path) {
-            Some(dir) => {
-                let dir = Box::new(dir);
-                Box::into_raw(dir) as *mut libc::DIR
-            }
-            None => std::ptr::null_mut(),
-        }
-    }
+    let Some(resolved) = util::kompo_path(raw) else {
+        return unsafe { kompo_wrap::OPENDIR_HANDLE(path) };
+    };
 
-    if WORKING_DIR.read().unwrap().is_some() && unsafe { *path } != b'/'.try_into().unwrap() {
-        let expand_path = unsafe { util::expand_kompo_path(path) };
-        inner_opendir(expand_path)
-    } else if unsafe { util::is_under_kompo_working_dir(path) } {
-        inner_opendir(path)
-    } else {
-        unsafe { kompo_wrap::OPENDIR_HANDLE(path) }
+    match fs().opendir(&resolved) {
+        Some(dir) => Box::into_raw(Box::new(dir)) as *mut libc::DIR,
+        None => std::ptr::null_mut(),
     }
 }
 
 #[unsafe(no_mangle)]
 pub fn rewinddir_from_fs(dir: *mut libc::DIR) {
-    fn inner_rewinddir(dir: *mut libc::DIR) {
-        let mut dir = unsafe { Box::from_raw(dir as *mut kompo_storage::FsDir) };
-
-        let trie = std::sync::Arc::clone(TRIE.get_or_init(initialize_trie));
-        trie.rewinddir(&mut dir);
-        let _ = Box::into_raw(dir);
+    if !unsafe { util::is_dir_exists_in_kompo(dir) } {
+        unsafe { kompo_wrap::REWINDDIR_HANDLE(dir) };
+        return;
     }
 
-    if unsafe { util::is_dir_exists_in_kompo(dir) } {
-        inner_rewinddir(dir)
-    } else {
-        unsafe { kompo_wrap::REWINDDIR_HANDLE(dir) }
-    }
+    let mut handle = unsafe { Box::from_raw(dir as *mut kompo_tree::FsDir) };
+    fs().rewinddir(&mut handle);
+    let _ = Box::into_raw(handle);
 }
 
+/// # Safety
+/// `path` must be a valid pointer to a null-terminated C string, and
+/// `resolved_path` either null or a buffer of at least `PATH_MAX` bytes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn realpath_from_fs(
     path: *const libc::c_char,
     resolved_path: *mut libc::c_char,
 ) -> *const libc::c_char {
-    unsafe fn inner_realpath(
-        path: *const libc::c_char,
-        resolved_path: *mut libc::c_char,
-    ) -> *const libc::c_char {
-        if resolved_path.is_null() {
-            unsafe { util::expand_kompo_path(path) }
-        } else {
-            let expand_path = unsafe { CStr::from_ptr(util::expand_kompo_path(path)) };
-            let bytes = expand_path.to_bytes_with_nul();
-            unsafe {
-                std::ptr::copy_nonoverlapping(
-                    bytes.as_ptr() as *const libc::c_char,
-                    resolved_path,
-                    bytes.len(),
-                );
-            }
+    let raw = unsafe { util::path_bytes(path) };
 
-            resolved_path
-        }
+    let Some(resolved) = util::kompo_path(raw) else {
+        return unsafe { kompo_wrap::REALPATH_HANDLE(path, resolved_path) };
+    };
+
+    let canonical = CString::new(resolved.into_owned()).expect("path contains a null byte");
+
+    if resolved_path.is_null() {
+        // The caller frees this, matching realpath(path, NULL).
+        return canonical.into_raw();
     }
 
-    if (WORKING_DIR.read().unwrap().is_some() && unsafe { *path } != b'/'.try_into().unwrap())
-        || unsafe { util::is_under_kompo_working_dir(path) }
-    {
-        unsafe { inner_realpath(path, resolved_path) }
-    } else {
-        unsafe { kompo_wrap::REALPATH_HANDLE(path, resolved_path) }
+    let bytes = canonical.as_bytes_with_nul();
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            bytes.as_ptr() as *const libc::c_char,
+            resolved_path,
+            bytes.len(),
+        );
     }
+
+    resolved_path
 }
 
+/// `mkdir` on a directory that is already in the image succeeds; everything
+/// else inside the image fails, since the image is read only.
 #[unsafe(no_mangle)]
 pub fn mkdir_from_fs(path: *const libc::c_char, mode: libc::mode_t) -> libc::c_int {
-    fn inner_mkdir(path: *const libc::c_char) -> libc::c_int {
-        let layout = std::alloc::Layout::new::<libc::stat>();
-        let stat_buf = unsafe { std::alloc::alloc(layout) as *mut libc::stat };
+    let raw = unsafe { util::path_bytes(path) };
 
-        let ret = stat_from_fs(path, stat_buf);
+    let Some(resolved) = util::kompo_path(raw) else {
+        return unsafe { kompo_wrap::MKDIR_HANDLE(path, mode) };
+    };
 
-        unsafe { std::alloc::dealloc(stat_buf as *mut u8, layout) };
-
-        if ret == 0 {
-            return 0;
-        }
-
-        errno::set_errno(errno::Errno(libc::ENOENT));
-        -1
+    if fs().lookup(&resolved).is_some() {
+        return 0;
     }
 
-    if WORKING_DIR.read().unwrap().is_some() && unsafe { *path } != b'/'.try_into().unwrap() {
-        let expand_path = unsafe { util::expand_kompo_path(path) };
-        inner_mkdir(expand_path)
-    } else if unsafe { util::is_under_kompo_working_dir(path) } {
-        inner_mkdir(path)
-    } else {
-        unsafe { kompo_wrap::MKDIR_HANDLE(path, mode) }
-    }
+    enoent()
 }
 
 #[cfg(target_os = "macos")]
@@ -605,40 +379,23 @@ pub fn getattrlist_from_fs(
     attr_buf_size: libc::size_t,
     options: libc::c_ulong,
 ) -> libc::c_int {
-    fn inner_getattrlist(
-        path: *const libc::c_char,
-        attr_list: *mut libc::c_void,
-        attr_buf: *mut libc::c_void,
-        attr_buf_size: libc::size_t,
-    ) -> libc::c_int {
-        let path_cstr = unsafe { CStr::from_ptr(path) };
-        let path_path = Path::new(path_cstr.to_str().expect("invalid path"));
-        let search_path = path_path.iter().collect::<Vec<_>>();
+    let raw = unsafe { util::path_bytes(path) };
 
-        let trie = std::sync::Arc::clone(TRIE.get_or_init(initialize_trie));
+    let Some(resolved) = util::kompo_path(raw) else {
+        return unsafe {
+            kompo_wrap::GETATTRLIST_HANDLE(path, attr_list, attr_buf, attr_buf_size, options)
+        };
+    };
 
-        let ret = trie.getattrlist(
-            &search_path,
-            unsafe { &*(attr_list as *const libc::attrlist) },
-            attr_buf,
-            attr_buf_size,
-        );
+    let ret = fs().getattrlist(
+        &resolved,
+        unsafe { &*(attr_list as *const libc::attrlist) },
+        attr_buf,
+        attr_buf_size,
+    );
 
-        match ret {
-            Some(r) => r,
-            None => {
-                errno::set_errno(errno::Errno(libc::ENOENT));
-                -1
-            }
-        }
-    }
-
-    if WORKING_DIR.read().unwrap().is_some() && unsafe { *path } != b'/'.try_into().unwrap() {
-        let expand_path = unsafe { util::expand_kompo_path(path) };
-        inner_getattrlist(expand_path, attr_list, attr_buf, attr_buf_size)
-    } else if unsafe { util::is_under_kompo_working_dir(path) } {
-        inner_getattrlist(path, attr_list, attr_buf, attr_buf_size)
-    } else {
-        unsafe { kompo_wrap::GETATTRLIST_HANDLE(path, attr_list, attr_buf, attr_buf_size, options) }
+    match ret {
+        Some(r) => r,
+        None => enoent(),
     }
 }

--- a/kompo_fs/src/lib.rs
+++ b/kompo_fs/src/lib.rs
@@ -9,7 +9,6 @@ use std::ffi::CString;
 /// atomic refcount bump for nothing.
 static FS: std::sync::OnceLock<kompo_tree::Fs<'static>> = std::sync::OnceLock::new();
 
-/// The packed filesystem, initialising it on first use.
 pub fn fs() -> &'static kompo_tree::Fs<'static> {
     FS.get_or_init(initialize_fs)
 }
@@ -164,7 +163,6 @@ unsafe extern "C" fn is_context_func(_: VALUE, _: VALUE) -> VALUE {
 pub fn initialize_fs() -> kompo_tree::Fs<'static> {
     let compression_enabled = unsafe { COMPRESSION_ENABLED } != 0;
 
-    // If compression is enabled, decompress all files first
     if compression_enabled {
         decompress_all_files();
     }
@@ -172,7 +170,6 @@ pub fn initialize_fs() -> kompo_tree::Fs<'static> {
     let paths =
         unsafe { std::slice::from_raw_parts(&raw const PATHS as *const u8, PATHS_SIZE as _) };
 
-    // Use FILES_BUFFER when compression is enabled, FILES otherwise
     let files = if compression_enabled {
         unsafe {
             std::slice::from_raw_parts(&raw const FILES_BUFFER as *const u8, FILES_BUFFER_SIZE as _)
@@ -181,8 +178,8 @@ pub fn initialize_fs() -> kompo_tree::Fs<'static> {
         unsafe { std::slice::from_raw_parts(&raw const FILES as *const u8, FILES_SIZE as _) }
     };
 
-    // FILES_SIZES holds cumulative offsets, so it has one more entry than there
-    // are paths. Use ORIGINAL_SIZES when compression is enabled.
+    // FILES_SIZES holds cumulative offsets, so it has one more entry than
+    // there are paths.
     let count = kompo_tree::path_count(paths);
     let file_offsets = unsafe {
         std::slice::from_raw_parts(

--- a/kompo_fs/src/lib.rs
+++ b/kompo_fs/src/lib.rs
@@ -528,6 +528,24 @@ mod tests {
         WORKING_DIR.write().unwrap().take();
     }
 
+    /// `realpath(3)` promises a canonical path, so an oddly spelled argument
+    /// must not come back unchanged.
+    #[test]
+    #[serial]
+    fn realpath_canonicalises() {
+        WORKING_DIR.write().unwrap().take();
+
+        let path = CString::new("/test/./hello.txt").unwrap();
+        let resolved = unsafe { glue::realpath_from_fs(path.as_ptr(), std::ptr::null_mut()) };
+        assert!(!resolved.is_null());
+        assert_eq!(
+            unsafe { CStr::from_ptr(resolved) }.to_bytes(),
+            b"/test/hello.txt"
+        );
+
+        unsafe { drop(CString::from_raw(resolved as *mut libc::c_char)) };
+    }
+
     #[test]
     #[serial]
     fn test_kompo_fs_set_entrypoint_dir_with_valid_path() {

--- a/kompo_fs/src/lib.rs
+++ b/kompo_fs/src/lib.rs
@@ -528,6 +528,21 @@ mod tests {
         WORKING_DIR.write().unwrap().take();
     }
 
+    /// The working directory is matched as a byte prefix, so a sibling whose
+    /// name merely extends it must not be captured.
+    #[test]
+    fn a_sibling_of_the_working_dir_is_not_ours() {
+        let path = CString::new("/testing/hello.txt").unwrap();
+        let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+
+        // Not in the image, and not the VFS's to answer -- it falls through to
+        // the real filesystem, where it does not exist either.
+        assert_eq!(glue::stat_from_fs(path.as_ptr(), &mut stat_buf), -1);
+        assert!(!util::is_under_kompo_working_dir(b"/testing/hello.txt"));
+        assert!(util::is_under_kompo_working_dir(b"/test/hello.txt"));
+        assert!(util::is_under_kompo_working_dir(b"/test"));
+    }
+
     /// `realpath(3)` promises a canonical path, so an oddly spelled argument
     /// must not come back unchanged.
     #[test]

--- a/kompo_fs/src/lib.rs
+++ b/kompo_fs/src/lib.rs
@@ -183,7 +183,7 @@ pub fn initialize_fs() -> kompo_tree::Fs<'static> {
 
     // FILES_SIZES holds cumulative offsets, so it has one more entry than there
     // are paths. Use ORIGINAL_SIZES when compression is enabled.
-    let count = paths.split_inclusive(|&b| b == b'\0').count();
+    let count = kompo_tree::path_count(paths);
     let file_offsets = unsafe {
         std::slice::from_raw_parts(
             if compression_enabled {
@@ -195,7 +195,17 @@ pub fn initialize_fs() -> kompo_tree::Fs<'static> {
         )
     };
 
-    kompo_tree::Fs::new(paths, files, file_offsets)
+    let fs = kompo_tree::Fs::new(paths, files, file_offsets);
+
+    // The generator canonicalises every path. If that ever stops being true,
+    // lookups stay correct but give up their fast miss, so catch it here --
+    // this is the only place a real image enters the index.
+    debug_assert!(
+        fs.paths_are_canonical(),
+        "generator emitted a non-canonical path"
+    );
+
+    fs
 }
 
 /// # Safety
@@ -222,13 +232,13 @@ pub unsafe extern "C" fn kompo_fs_set_entrypoint_dir(entrypoint_path: *const lib
 
     let path = unsafe { util::path_bytes(entrypoint_path) };
 
-    // The generator emits this canonical, so the parent directory is simply
-    // everything before the last separator.
-    let Some(slash) = path.iter().rposition(|&b| b == b'/') else {
+    // The generator emits this canonical, so the parent is everything before
+    // the last separator.
+    let Some(end) = util::parent_end(path) else {
         return;
     };
 
-    *WORKING_DIR.write().unwrap() = Some(path[..slash.max(1)].to_vec());
+    *WORKING_DIR.write().unwrap() = Some(path[..end].to_vec());
 }
 
 #[cfg(test)]

--- a/kompo_fs/src/lib.rs
+++ b/kompo_fs/src/lib.rs
@@ -1,23 +1,25 @@
 mod glue;
 pub mod util;
-use std::ffi::CStr;
 use std::ffi::CString;
-use std::ops::Range;
-use std::path::Path;
-use trie_rs::map::TrieBuilder;
 
-static TRIE: std::sync::OnceLock<std::sync::Arc<kompo_storage::Fs>> = std::sync::OnceLock::new();
+/// The packed filesystem, built the first time a call needs it.
+///
+/// Held directly rather than behind an `Arc`, since `OnceLock` already hands
+/// out a `&'static`; the previous `Arc::clone` per intercepted call was an
+/// atomic refcount bump for nothing.
+static FS: std::sync::OnceLock<kompo_tree::Fs<'static>> = std::sync::OnceLock::new();
 
-pub static WORKING_DIR: std::sync::RwLock<Option<std::ffi::OsString>> =
-    std::sync::RwLock::new(None);
+/// The packed filesystem, initialising it on first use.
+pub fn fs() -> &'static kompo_tree::Fs<'static> {
+    FS.get_or_init(initialize_fs)
+}
+
+/// Absolute path of the current directory, while it is inside the image.
+pub static WORKING_DIR: std::sync::RwLock<Option<Vec<u8>>> = std::sync::RwLock::new(None);
 
 pub static THREAD_CONTEXT: std::sync::OnceLock<
     std::sync::Arc<std::sync::RwLock<std::collections::HashMap<libc::pthread_t, bool>>>,
 > = std::sync::OnceLock::new();
-
-static FILE_TYPE_CACHE: std::sync::LazyLock<
-    std::sync::RwLock<std::collections::HashMap<Vec<std::ffi::OsString>, libc::stat>>,
-> = std::sync::LazyLock::new(|| std::sync::RwLock::new(std::collections::HashMap::new()));
 
 #[allow(clippy::upper_case_acronyms)]
 type VALUE = u64;
@@ -80,10 +82,6 @@ unsafe extern "C" {
         data2: VALUE,
     ) -> VALUE;
     fn rb_yield(v: VALUE) -> VALUE;
-}
-
-fn initialize_trie() -> std::sync::Arc<kompo_storage::Fs<'static>> {
-    std::sync::Arc::new(initialize_fs())
 }
 
 /// Decompress all files from COMPRESSED_FILES into FILES_BUFFER using zlib
@@ -159,7 +157,11 @@ unsafe extern "C" fn is_context_func(_: VALUE, _: VALUE) -> VALUE {
     }
 }
 
-pub fn initialize_fs() -> kompo_storage::Fs<'static> {
+/// Index the blobs the linker placed in the binary.
+///
+/// Nothing is copied or re-encoded here: the index borrows `PATHS` and `FILES`
+/// where they already sit, so this is the whole of the startup cost.
+pub fn initialize_fs() -> kompo_tree::Fs<'static> {
     let compression_enabled = unsafe { COMPRESSION_ENABLED } != 0;
 
     // If compression is enabled, decompress all files first
@@ -167,52 +169,33 @@ pub fn initialize_fs() -> kompo_storage::Fs<'static> {
         decompress_all_files();
     }
 
-    let mut builder = TrieBuilder::new();
-
-    let path_slice = unsafe {
-        std::slice::from_raw_parts(&PATHS as *const libc::c_char as *const u8, PATHS_SIZE as _)
-    };
+    let paths =
+        unsafe { std::slice::from_raw_parts(&raw const PATHS as *const u8, PATHS_SIZE as _) };
 
     // Use FILES_BUFFER when compression is enabled, FILES otherwise
-    let file_slice = if compression_enabled {
+    let files = if compression_enabled {
         unsafe {
-            std::slice::from_raw_parts(
-                std::ptr::addr_of!(FILES_BUFFER) as *const libc::c_char as *const u8,
-                FILES_BUFFER_SIZE as _,
-            )
+            std::slice::from_raw_parts(&raw const FILES_BUFFER as *const u8, FILES_BUFFER_SIZE as _)
         }
     } else {
-        unsafe {
-            std::slice::from_raw_parts(&FILES as *const libc::c_char as *const u8, FILES_SIZE as _)
-        }
+        unsafe { std::slice::from_raw_parts(&raw const FILES as *const u8, FILES_SIZE as _) }
     };
 
-    let splited_path_array = path_slice
-        .split_inclusive(|a| *a == b'\0')
-        .collect::<Vec<_>>();
-
-    // Use ORIGINAL_SIZES when compression is enabled, FILES_SIZES otherwise
-    let files_sizes = if compression_enabled {
-        unsafe { std::slice::from_raw_parts(&ORIGINAL_SIZES, splited_path_array.len() + 1) }
-    } else {
-        unsafe { std::slice::from_raw_parts(&FILES_SIZES, splited_path_array.len() + 1) }
+    // FILES_SIZES holds cumulative offsets, so it has one more entry than there
+    // are paths. Use ORIGINAL_SIZES when compression is enabled.
+    let count = paths.split_inclusive(|&b| b == b'\0').count();
+    let file_offsets = unsafe {
+        std::slice::from_raw_parts(
+            if compression_enabled {
+                &raw const ORIGINAL_SIZES
+            } else {
+                &raw const FILES_SIZES
+            },
+            count + 1,
+        )
     };
 
-    for (i, path_byte) in splited_path_array.into_iter().enumerate() {
-        let path = Path::new(unsafe {
-            let bytes = std::slice::from_raw_parts(path_byte.as_ptr(), path_byte.len());
-            CStr::from_bytes_with_nul_unchecked(bytes).to_str().unwrap()
-        });
-        let path = path.iter().collect::<Vec<_>>();
-
-        let range: Range<usize> = files_sizes[i] as usize..files_sizes[i + 1] as usize;
-        let file = &file_slice[range];
-        let file = unsafe { std::slice::from_raw_parts(file.as_ptr(), file.len()) };
-
-        builder.push(path, file);
-    }
-
-    kompo_storage::Fs::new(builder)
+    kompo_tree::Fs::new(paths, files, file_offsets)
 }
 
 /// # Safety
@@ -237,13 +220,15 @@ pub unsafe extern "C" fn kompo_fs_set_entrypoint_dir(entrypoint_path: *const lib
         return;
     }
 
-    let path_cstr = unsafe { CStr::from_ptr(entrypoint_path) };
-    let path = Path::new(path_cstr.to_str().expect("invalid entrypoint path"));
+    let path = unsafe { util::path_bytes(entrypoint_path) };
 
-    if let Some(parent) = path.parent() {
-        let parent_os_str = parent.as_os_str().to_os_string();
-        *WORKING_DIR.write().unwrap() = Some(parent_os_str);
-    }
+    // The generator emits this canonical, so the parent directory is simply
+    // everything before the last separator.
+    let Some(slash) = path.iter().rposition(|&b| b == b'/') else {
+        return;
+    };
+
+    *WORKING_DIR.write().unwrap() = Some(path[..slash.max(1)].to_vec());
 }
 
 #[cfg(test)]
@@ -252,17 +237,15 @@ mod tests {
 
     use super::*;
     use serial_test::serial;
+    use std::ffi::CStr;
     use std::ffi::CString;
 
     #[test]
     fn test_initialize_fs() {
         let fs = initialize_fs();
         // Verify we can access files from the test data
-        let path = std::path::Path::new("/test/hello.txt");
-        let path_vec: Vec<&std::ffi::OsStr> = path.iter().collect();
-
         let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
-        let result = fs.stat(&path_vec, &mut stat_buf);
+        let result = fs.stat(b"/test/hello.txt", &mut stat_buf);
         assert!(result.is_some());
         assert_eq!(stat_buf.st_size, 13); // "Hello, World!" is 13 bytes
     }
@@ -512,6 +495,39 @@ mod tests {
         );
     }
 
+    /// The reason paths are handled as bytes. Nothing validates encoding when
+    /// the image is built, so a gem shipping a Latin-1 filename reaches us as
+    /// invalid UTF-8; this used to panic inside `to_str().unwrap()`.
+    #[test]
+    fn non_utf8_path_does_not_panic() {
+        let path = CString::new(b"/test/caf\xE9.rb".to_vec()).unwrap();
+        let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+
+        let result = glue::stat_from_fs(path.as_ptr(), &mut stat_buf);
+        assert_eq!(result, -1);
+        assert_eq!(errno::errno().0, libc::ENOENT);
+    }
+
+    #[test]
+    #[serial]
+    fn relative_paths_resolve_against_the_working_dir() {
+        let entrypoint = CString::new("/test/main.rb").unwrap();
+        unsafe { kompo_fs_set_entrypoint_dir(entrypoint.as_ptr()) };
+
+        let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+        let relative = CString::new("hello.txt").unwrap();
+        assert_eq!(glue::stat_from_fs(relative.as_ptr(), &mut stat_buf), 0);
+        assert_eq!(stat_buf.st_size, 13);
+
+        // `.` and `..` are resolved against the working directory too.
+        let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+        let winding = CString::new("./sub/../hello.txt").unwrap();
+        assert_eq!(glue::stat_from_fs(winding.as_ptr(), &mut stat_buf), 0);
+        assert_eq!(stat_buf.st_size, 13);
+
+        WORKING_DIR.write().unwrap().take();
+    }
+
     #[test]
     #[serial]
     fn test_kompo_fs_set_entrypoint_dir_with_valid_path() {
@@ -528,7 +544,7 @@ mod tests {
         let working_dir = WORKING_DIR.write().unwrap().take();
         assert!(working_dir.is_some());
         let dir_path = working_dir.unwrap();
-        assert_eq!(dir_path.to_str().unwrap(), "/app/bin");
+        assert_eq!(dir_path, b"/app/bin");
     }
 
     #[test]
@@ -563,6 +579,6 @@ mod tests {
         let working_dir = WORKING_DIR.write().unwrap().take();
         assert!(working_dir.is_some());
         let dir_path = working_dir.unwrap();
-        assert_eq!(dir_path.to_str().unwrap(), "/");
+        assert_eq!(dir_path, b"/");
     }
 }

--- a/kompo_fs/src/util.rs
+++ b/kompo_fs/src/util.rs
@@ -14,6 +14,14 @@ pub fn is_under_kompo_working_dir(path: &[u8]) -> bool {
     path.starts_with(wd) && matches!(path.get(wd.len()), None | Some(b'/'))
 }
 
+/// Index just past the parent directory of `path`, or `None` if it has no
+/// separator to split on. Never points past the root.
+pub fn parent_end(path: &[u8]) -> Option<usize> {
+    path.iter()
+        .rposition(|&b| b == b'/')
+        .map(|slash| slash.max(1))
+}
+
 /// Join `rel` onto `base`, resolving `.` and `..` lexically.
 ///
 /// Nothing here touches the real filesystem, so it cannot follow a symlink the
@@ -27,9 +35,8 @@ pub fn join_normalized(base: &[u8], rel: &[u8]) -> Vec<u8> {
         match comp {
             b"" | b"." => {}
             b".." => {
-                if let Some(slash) = out.iter().rposition(|&b| b == b'/') {
-                    // Never pop past the root.
-                    out.truncate(slash.max(1));
+                if let Some(end) = parent_end(&out) {
+                    out.truncate(end);
                 }
             }
             _ => {
@@ -61,6 +68,19 @@ pub fn kompo_path(path: &[u8]) -> Option<Cow<'_, [u8]>> {
     Some(Cow::Owned(join_normalized(working_dir, path)))
 }
 
+/// Like [`kompo_path`], for the `*at` calls.
+///
+/// A relative name is only ours when it resolves against the working
+/// directory, which is what `AT_FDCWD` asks for; any other `dirfd` names a
+/// directory in the real filesystem.
+pub fn kompo_path_at(dirfd: libc::c_int, path: &[u8]) -> Option<Cow<'_, [u8]>> {
+    if path.first() != Some(&b'/') && dirfd != libc::AT_FDCWD {
+        return None;
+    }
+
+    kompo_path(path)
+}
+
 /// Read a C path argument as bytes.
 ///
 /// # Safety
@@ -84,11 +104,9 @@ pub unsafe fn is_dir_exists_in_kompo(dir: *mut libc::DIR) -> bool {
         return false;
     }
 
-    let dir = unsafe { Box::from_raw(dir as *mut kompo_tree::FsDir) };
-    let exists = fs.is_dir_exists(&dir);
-    let _ = Box::into_raw(dir);
+    let dir = unsafe { &*(dir as *const kompo_tree::FsDir) };
 
-    exists
+    fs.is_dir_exists(dir)
 }
 
 #[cfg(test)]

--- a/kompo_fs/src/util.rs
+++ b/kompo_fs/src/util.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::ffi::CStr;
+use std::sync::OnceLock;
 
 use crate::{FS, WD, WORKING_DIR};
 
@@ -9,9 +10,20 @@ use crate::{FS, WD, WORKING_DIR};
 /// prefix match answers it. The boundary check is what keeps a sibling like
 /// `/tmp/kompo-abcdefg` out when the working directory is `/tmp/kompo-abcdef`.
 pub fn is_under_kompo_working_dir(path: &[u8]) -> bool {
-    let wd = unsafe { CStr::from_ptr(&raw const WD) }.to_bytes();
+    let wd = working_dir_prefix();
 
     path.starts_with(wd) && matches!(path.get(wd.len()), None | Some(b'/'))
+}
+
+/// The packed working directory, measured once.
+///
+/// `WD` is a linker constant, so the `strlen` behind `CStr::from_ptr` finds the
+/// same answer every time -- and this runs on the reject path of every
+/// intercepted call, before we know the path is not ours.
+fn working_dir_prefix() -> &'static [u8] {
+    static PREFIX: OnceLock<&'static [u8]> = OnceLock::new();
+
+    PREFIX.get_or_init(|| unsafe { CStr::from_ptr(&raw const WD) }.to_bytes())
 }
 
 /// Index just past the parent directory of `path`, or `None` if it has no

--- a/kompo_fs/src/util.rs
+++ b/kompo_fs/src/util.rs
@@ -26,8 +26,8 @@ fn working_dir_prefix() -> &'static [u8] {
     PREFIX.get_or_init(|| unsafe { CStr::from_ptr(&raw const WD) }.to_bytes())
 }
 
-/// Index just past the parent directory of `path`, or `None` if it has no
-/// separator to split on. Never points past the root.
+/// Index just past the parent directory of `path`, clamped so it never points
+/// above the root, or `None` when there is no separator to split on.
 pub fn parent_end(path: &[u8]) -> Option<usize> {
     path.iter()
         .rposition(|&b| b == b'/')
@@ -93,8 +93,6 @@ pub fn kompo_path_at(dirfd: libc::c_int, path: &[u8]) -> Option<Cow<'_, [u8]>> {
     kompo_path(path)
 }
 
-/// Read a C path argument as bytes.
-///
 /// # Safety
 /// `path` must be a valid pointer to a null-terminated C string.
 pub unsafe fn path_bytes<'a>(path: *const libc::c_char) -> &'a [u8] {

--- a/kompo_fs/src/util.rs
+++ b/kompo_fs/src/util.rs
@@ -1,233 +1,164 @@
-use std::{
-    env,
-    ffi::{CStr, CString},
-    hash::{DefaultHasher, Hash, Hasher},
-    os::unix::ffi::OsStrExt,
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use std::borrow::Cow;
+use std::ffi::CStr;
 
-use crate::{TRIE, WD, WORKING_DIR};
+use crate::{FS, WD, WORKING_DIR};
 
-/// # Safety
-/// `other_path` must be a valid pointer to a null-terminated C string.
-pub unsafe fn is_under_kompo_working_dir(other_path: *const libc::c_char) -> bool {
-    let wd = unsafe { CStr::from_ptr(&WD) };
-    let other_path = unsafe { CStr::from_ptr(other_path) };
+/// Is `path` inside the packed working directory?
+///
+/// The generator emits `WD` canonical and without a trailing slash, so a byte
+/// prefix match answers it.
+pub fn is_under_kompo_working_dir(path: &[u8]) -> bool {
+    let wd = unsafe { CStr::from_ptr(&raw const WD) }.to_bytes();
 
-    other_path.to_bytes().starts_with(wd.to_bytes())
+    path.starts_with(wd)
 }
 
-pub fn canonicalize_path(base: &mut PathBuf, join_path: &Path) {
-    for comp in join_path.components() {
+/// Join `rel` onto `base`, resolving `.` and `..` lexically.
+///
+/// Nothing here touches the real filesystem, so it cannot follow a symlink the
+/// way `realpath(3)` would. The image holds no symlinks, so there is nothing to
+/// follow.
+pub fn join_normalized(base: &[u8], rel: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(base.len() + 1 + rel.len());
+    out.extend_from_slice(base);
+
+    for comp in rel.split(|&b| b == b'/') {
         match comp {
-            std::path::Component::Normal(comp) => {
-                base.push(comp);
+            b"" | b"." => {}
+            b".." => {
+                if let Some(slash) = out.iter().rposition(|&b| b == b'/') {
+                    // Never pop past the root.
+                    out.truncate(slash.max(1));
+                }
             }
-            std::path::Component::ParentDir => {
-                base.pop();
-            }
-            std::path::Component::RootDir => {
-                // do nothing
-            }
-            std::path::Component::Prefix(_) => todo!(),
-            std::path::Component::CurDir => {
-                // do nothing
+            _ => {
+                if out.last() != Some(&b'/') {
+                    out.push(b'/');
+                }
+                out.extend_from_slice(comp);
             }
         }
     }
+
+    out
 }
 
-/// # Safety
-/// `raw_path` must be a valid pointer to a null-terminated C string.
-pub unsafe fn expand_kompo_path(raw_path: *const libc::c_char) -> *const libc::c_char {
-    let path = unsafe { CStr::from_ptr(raw_path) };
-    let path = PathBuf::from_str(path.to_str().expect("invalid path")).expect("invalid path");
-
-    if path.is_absolute() {
-        let path = CString::new(path.to_str().expect("invalid path"))
-            .expect("invalid path")
-            .into_boxed_c_str();
-        let path = Box::into_raw(path);
-
-        return path as *const libc::c_char;
+/// The absolute path this call should resolve inside the image, or `None` when
+/// it belongs to the real filesystem.
+///
+/// An absolute path is borrowed as-is; a relative one is joined onto the
+/// working directory, which only means anything while that directory is itself
+/// inside the image.
+pub fn kompo_path(path: &[u8]) -> Option<Cow<'_, [u8]>> {
+    if path.first() == Some(&b'/') {
+        return is_under_kompo_working_dir(path).then_some(Cow::Borrowed(path));
     }
 
-    let wd = WORKING_DIR.read().unwrap().clone().unwrap();
-    let mut wd = PathBuf::from(wd);
+    let working_dir = WORKING_DIR.read().ok()?;
+    let working_dir = working_dir.as_deref()?;
 
-    canonicalize_path(&mut wd, &path);
-
-    let wd = CString::new(wd.to_str().expect("invalid path"))
-        .expect("invalid path")
-        .into_boxed_c_str();
-    let wd = Box::into_raw(wd);
-
-    wd as *const libc::c_char
+    Some(Cow::Owned(join_normalized(working_dir, path)))
 }
 
-pub fn current_dir_hash() -> u64 {
-    let mut hasher = DefaultHasher::new();
-    WORKING_DIR
-        .read()
-        .unwrap()
-        .as_ref()
-        .unwrap()
-        .hash(&mut hasher);
-    hasher.finish()
-}
-
+/// Read a C path argument as bytes.
+///
 /// # Safety
-/// `other_path` must be a valid pointer to a null-terminated C string.
-pub unsafe fn is_under_kompo_tmp_dir(other_path: *const libc::c_char) -> bool {
-    let mut tmpdir = env::temp_dir();
-    tmpdir.push(format!("{}", current_dir_hash()));
-    let other_path = unsafe { CStr::from_ptr(other_path) };
-
-    other_path
-        .to_bytes()
-        .starts_with(tmpdir.as_os_str().as_bytes())
+/// `path` must be a valid pointer to a null-terminated C string.
+pub unsafe fn path_bytes<'a>(path: *const libc::c_char) -> &'a [u8] {
+    unsafe { CStr::from_ptr(path) }.to_bytes()
 }
 
 pub fn is_fd_exists_in_kompo(fd: i32) -> bool {
-    if TRIE.get().is_none() {
-        return false;
-    }
-
-    let trie = std::sync::Arc::clone(TRIE.get().unwrap());
-    trie.is_fd_exists(fd)
+    FS.get().is_some_and(|fs| fs.is_fd_exists(fd))
 }
 
 /// # Safety
-/// `dir` must be a valid pointer to a `FsDir` that was previously allocated by this crate.
+/// `dir` must be a valid pointer to an `FsDir` that was previously allocated by
+/// this crate.
 pub unsafe fn is_dir_exists_in_kompo(dir: *mut libc::DIR) -> bool {
-    if TRIE.get().is_none() {
+    let Some(fs) = FS.get() else {
+        return false;
+    };
+    if dir.is_null() {
         return false;
     }
 
-    let dir = unsafe { Box::from_raw(dir as *mut kompo_storage::FsDir) };
-
-    let trie = std::sync::Arc::clone(TRIE.get().unwrap());
-    let bool = trie.is_dir_exists(&dir);
-
+    let dir = unsafe { Box::from_raw(dir as *mut kompo_tree::FsDir) };
+    let exists = fs.is_dir_exists(&dir);
     let _ = Box::into_raw(dir);
-    bool
+
+    exists
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
 
     #[test]
-    fn test_canonicalize_path_simple() {
-        let mut base = PathBuf::from("/home/user");
-        let join_path = PathBuf::from("documents");
-
-        canonicalize_path(&mut base, &join_path);
-
-        assert_eq!(base, PathBuf::from("/home/user/documents"));
+    fn join_normalized_appends_components() {
+        assert_eq!(
+            join_normalized(b"/home/user", b"documents"),
+            b"/home/user/documents"
+        );
+        assert_eq!(
+            join_normalized(b"/home/user", b"documents/work"),
+            b"/home/user/documents/work"
+        );
     }
 
     #[test]
-    fn test_canonicalize_path_with_parent_dir() {
-        let mut base = PathBuf::from("/home/user/projects");
-        let join_path = PathBuf::from("../documents");
-
-        canonicalize_path(&mut base, &join_path);
-
-        assert_eq!(base, PathBuf::from("/home/user/documents"));
+    fn join_normalized_resolves_parent_components() {
+        assert_eq!(
+            join_normalized(b"/home/user/projects", b"../documents"),
+            b"/home/user/documents"
+        );
+        assert_eq!(
+            join_normalized(b"/home/user/projects/rust", b"../../documents/work"),
+            b"/home/user/documents/work"
+        );
+        assert_eq!(
+            join_normalized(b"/home/user/documents", b".."),
+            b"/home/user"
+        );
     }
 
     #[test]
-    fn test_canonicalize_path_multiple_parent_dirs() {
-        let mut base = PathBuf::from("/home/user/projects/rust");
-        let join_path = PathBuf::from("../../documents/work");
-
-        canonicalize_path(&mut base, &join_path);
-
-        assert_eq!(base, PathBuf::from("/home/user/documents/work"));
+    fn join_normalized_drops_current_dir_components() {
+        assert_eq!(
+            join_normalized(b"/home/user", b"./documents/./work"),
+            b"/home/user/documents/work"
+        );
+        assert_eq!(join_normalized(b"/home/user", b"."), b"/home/user");
+        assert_eq!(join_normalized(b"/home/user", b""), b"/home/user");
     }
 
     #[test]
-    fn test_canonicalize_path_with_current_dir() {
-        let mut base = PathBuf::from("/home/user");
-        let join_path = PathBuf::from("./documents/./work");
-
-        canonicalize_path(&mut base, &join_path);
-
-        assert_eq!(base, PathBuf::from("/home/user/documents/work"));
+    fn join_normalized_handles_mixed_components() {
+        assert_eq!(
+            join_normalized(b"/home/user/projects", b"./rust/../go/./src"),
+            b"/home/user/projects/go/src"
+        );
+        assert_eq!(join_normalized(b"/", b"a/b/c/../d/./e"), b"/a/b/d/e");
     }
 
     #[test]
-    fn test_canonicalize_path_complex() {
-        let mut base = PathBuf::from("/home/user/projects");
-        let join_path = PathBuf::from("./rust/../go/./src");
+    fn join_normalized_never_escapes_the_root() {
+        assert_eq!(join_normalized(b"/home", b"../../etc"), b"/etc");
+        assert_eq!(join_normalized(b"/", b".."), b"/");
+    }
 
-        canonicalize_path(&mut base, &join_path);
-
-        assert_eq!(base, PathBuf::from("/home/user/projects/go/src"));
+    /// A leading separator in the joined path is a component boundary, not a
+    /// restart -- this matches how the previous `PathBuf`-based version behaved.
+    #[test]
+    fn join_normalized_treats_a_rooted_join_as_relative() {
+        assert_eq!(
+            join_normalized(b"/home/user", b"/etc/config"),
+            b"/home/user/etc/config"
+        );
     }
 
     #[test]
-    fn test_canonicalize_path_absolute_in_join() {
-        let mut base = PathBuf::from("/home/user");
-        let join_path = PathBuf::from("/etc/config");
-
-        canonicalize_path(&mut base, &join_path);
-
-        // RootDir component is ignored, so only "etc" and "config" are added
-        assert_eq!(base, PathBuf::from("/home/user/etc/config"));
-    }
-
-    #[test]
-    fn test_canonicalize_path_parent_beyond_root() {
-        let mut base = PathBuf::from("/home");
-        let join_path = PathBuf::from("../../etc");
-
-        canonicalize_path(&mut base, &join_path);
-
-        // After two parent dirs from /home, we're at / then add etc
-        assert_eq!(base, PathBuf::from("/etc"));
-    }
-
-    #[test]
-    fn test_canonicalize_path_empty_join() {
-        let mut base = PathBuf::from("/home/user");
-        let join_path = PathBuf::from("");
-
-        canonicalize_path(&mut base, &join_path);
-
-        assert_eq!(base, PathBuf::from("/home/user"));
-    }
-
-    #[test]
-    fn test_canonicalize_path_only_current_dir() {
-        let mut base = PathBuf::from("/home/user");
-        let join_path = PathBuf::from(".");
-
-        canonicalize_path(&mut base, &join_path);
-
-        assert_eq!(base, PathBuf::from("/home/user"));
-    }
-
-    #[test]
-    fn test_canonicalize_path_only_parent_dir() {
-        let mut base = PathBuf::from("/home/user/documents");
-        let join_path = PathBuf::from("..");
-
-        canonicalize_path(&mut base, &join_path);
-
-        assert_eq!(base, PathBuf::from("/home/user"));
-    }
-
-    #[test]
-    fn test_canonicalize_path_nested_structure() {
-        let mut base = PathBuf::from("/");
-        let join_path = PathBuf::from("a/b/c/../d/./e");
-
-        canonicalize_path(&mut base, &join_path);
-
-        assert_eq!(base, PathBuf::from("/a/b/d/e"));
+    fn join_normalized_collapses_redundant_separators() {
+        assert_eq!(join_normalized(b"/home/user", b"a//b"), b"/home/user/a/b");
     }
 }

--- a/kompo_fs/src/util.rs
+++ b/kompo_fs/src/util.rs
@@ -6,11 +6,12 @@ use crate::{FS, WD, WORKING_DIR};
 /// Is `path` inside the packed working directory?
 ///
 /// The generator emits `WD` canonical and without a trailing slash, so a byte
-/// prefix match answers it.
+/// prefix match answers it. The boundary check is what keeps a sibling like
+/// `/tmp/kompo-abcdefg` out when the working directory is `/tmp/kompo-abcdef`.
 pub fn is_under_kompo_working_dir(path: &[u8]) -> bool {
     let wd = unsafe { CStr::from_ptr(&raw const WD) }.to_bytes();
 
-    path.starts_with(wd)
+    path.starts_with(wd) && matches!(path.get(wd.len()), None | Some(b'/'))
 }
 
 /// Join `rel` onto `base`, resolving `.` and `..` lexically.

--- a/kompo_tree/Cargo.toml
+++ b/kompo_tree/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "kompo_tree"
+version.workspace = true
+edition = "2024"
+
+[dependencies]
+libc = "0.2.169"
+rustc-hash = "2"
+
+[dev-dependencies]
+criterion = { version = "0.8.1", features = ["html_reports"] }
+kompo_storage = { path = "../kompo_storage" }
+trie-rs = "0.4.2"
+
+[[bench]]
+name = "tree_bench"
+harness = false

--- a/kompo_tree/benches/tree_bench.rs
+++ b/kompo_tree/benches/tree_bench.rs
@@ -1,0 +1,326 @@
+//! `kompo_tree` against the `kompo_storage` trie on the same filesystem image.
+//!
+//! Both sides are measured the way `kompo_fs::glue` actually calls them: the
+//! trie gets an absolute path split into components (what `glue` builds today),
+//! the tree gets the same path as bytes (what it would be handed instead). The
+//! split is part of the trie's cost because the trie's API requires it.
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::ffi::OsStr;
+use std::hint::black_box;
+use std::path::Path;
+
+static SMALL: &[u8] = &[b'#'; 512];
+static MEDIUM: &[u8] = &[b'#'; 4096];
+static LARGE: &[u8] = &[b'#'; 32768];
+
+fn leak(s: String) -> &'static str {
+    Box::leak(s.into_boxed_str())
+}
+
+/// A Rails app with its bundled gems, emitted gem by gem like the real image.
+fn image() -> Vec<(&'static str, &'static [u8])> {
+    let mut out: Vec<(&'static str, &'static [u8])> = Vec::new();
+
+    for dir in [
+        "models",
+        "controllers",
+        "views",
+        "helpers",
+        "jobs",
+        "mailers",
+        "channels",
+    ] {
+        for i in 0..30 {
+            out.push((
+                leak(format!(
+                    "/app/{}/{}{}.rb",
+                    dir,
+                    dir.trim_end_matches('s'),
+                    i
+                )),
+                MEDIUM,
+            ));
+        }
+    }
+    for version in ["v1", "v2"] {
+        for i in 0..20 {
+            out.push((
+                leak(format!(
+                    "/app/controllers/api/{}/controller{}.rb",
+                    version, i
+                )),
+                MEDIUM,
+            ));
+        }
+    }
+    for file in ["application.rb", "environment.rb", "routes.rb", "puma.rb"] {
+        out.push((leak(format!("/config/{}", file)), SMALL));
+    }
+    for i in 0..20 {
+        out.push((
+            leak(format!("/config/initializers/initializer{}.rb", i)),
+            SMALL,
+        ));
+    }
+    for i in 0..50 {
+        out.push((leak(format!("/lib/lib{}.rb", i)), MEDIUM));
+    }
+
+    let gems = [
+        "rails",
+        "activerecord",
+        "actionpack",
+        "activesupport",
+        "actionview",
+        "actionmailer",
+        "activejob",
+        "actioncable",
+        "railties",
+        "bundler",
+        "rake",
+        "thor",
+        "i18n",
+        "tzinfo",
+        "concurrent-ruby",
+        "sprockets",
+        "puma",
+        "bootsnap",
+        "byebug",
+        "listen",
+        "spring",
+        "capybara",
+        "rspec-rails",
+        "factory_bot",
+        "faker",
+        "devise",
+        "pundit",
+        "sidekiq",
+        "redis",
+        "pg",
+        "aws-sdk-s3",
+        "carrierwave",
+        "mini_magick",
+        "nokogiri",
+        "rack",
+        "sinatra",
+        "sequel",
+        "oj",
+        "msgpack",
+        "webmock",
+    ];
+    for gem in gems {
+        let count = match gem {
+            "rails" | "activerecord" | "actionpack" | "activesupport" => 200,
+            "aws-sdk-s3" => 150,
+            _ => 50,
+        };
+        for i in 0..count {
+            out.push((
+                leak(format!(
+                    "/vendor/bundle/ruby/3.2.0/gems/{}/lib/{}{}.rb",
+                    gem,
+                    gem.replace('-', "_"),
+                    i
+                )),
+                if i < 5 { LARGE } else { MEDIUM },
+            ));
+        }
+        if count > 100 {
+            for subdir in ["core", "util", "ext"] {
+                for i in 0..20 {
+                    out.push((
+                        leak(format!(
+                            "/vendor/bundle/ruby/3.2.0/gems/{}/lib/{}/{}{}.rb",
+                            gem, subdir, subdir, i
+                        )),
+                        MEDIUM,
+                    ));
+                }
+            }
+        }
+    }
+
+    out
+}
+
+fn build_trie(image: &[(&'static str, &'static [u8])]) -> kompo_storage::Fs<'static> {
+    let mut builder: trie_rs::map::TrieBuilder<&OsStr, &[u8]> = trie_rs::map::TrieBuilder::new();
+    for (path, data) in image {
+        let comps: Vec<&OsStr> = Path::new(*path).iter().collect();
+        builder.push(&comps, *data);
+    }
+    kompo_storage::Fs::new(builder)
+}
+
+/// The blobs the linker would hand us: assembled once, outside the measurement.
+fn blobs(
+    image: &[(&'static str, &'static [u8])],
+) -> (&'static [u8], &'static [u8], &'static [u64]) {
+    let mut paths = Vec::new();
+    let mut files = Vec::new();
+    let mut offsets = vec![0u64];
+    for (path, data) in image {
+        paths.extend_from_slice(path.as_bytes());
+        paths.push(0);
+        files.extend_from_slice(data);
+        offsets.push(files.len() as u64);
+    }
+    (Vec::leak(paths), Vec::leak(files), Vec::leak(offsets))
+}
+
+fn build_tree(image: &[(&'static str, &'static [u8])]) -> kompo_tree::Fs<'static> {
+    let (paths, files, offsets) = blobs(image);
+    kompo_tree::Fs::new(paths, files, offsets)
+}
+
+/// What `glue::stat_from_fs` does before it can call the trie.
+fn split(path: &str) -> Vec<&OsStr> {
+    Path::new(path).iter().collect()
+}
+
+const SHALLOW: &str = "/app/models/model0.rb";
+const DEEP: &str = "/vendor/bundle/ruby/3.2.0/gems/rails/lib/rails0.rb";
+/// A name `require` probes and does not find, inside a directory that exists.
+const MISS: &str = "/vendor/bundle/ruby/3.2.0/gems/rails/lib/rails0.so";
+
+/// Startup cost: the work done on the first intercepted syscall.
+///
+/// Both sides start from data already linked into the binary, so the blobs are
+/// assembled once up front and only the indexing is timed.
+fn bench_build(c: &mut Criterion) {
+    let image = image();
+    let (paths, files, offsets) = blobs(&image);
+
+    let mut group = c.benchmark_group("build");
+    group.sample_size(10);
+    group.bench_function("trie", |b| b.iter(|| build_trie(black_box(&image))));
+    group.bench_function("tree", |b| {
+        b.iter(|| kompo_tree::Fs::new(black_box(paths), black_box(files), black_box(offsets)))
+    });
+    group.finish();
+}
+
+fn bench_stat(c: &mut Criterion) {
+    let image = image();
+    let trie = build_trie(&image);
+    let tree = build_tree(&image);
+
+    let mut group = c.benchmark_group("stat");
+    for (name, path) in [("shallow", SHALLOW), ("deep", DEEP), ("miss", MISS)] {
+        group.bench_function(format!("trie/{name}"), |b| {
+            b.iter(|| {
+                let mut st: libc::stat = unsafe { std::mem::zeroed() };
+                let comps = split(black_box(path));
+                black_box(trie.stat(&comps, &mut st))
+            })
+        });
+        group.bench_function(format!("tree/{name}"), |b| {
+            b.iter(|| {
+                let mut st: libc::stat = unsafe { std::mem::zeroed() };
+                black_box(tree.stat(black_box(path.as_bytes()), &mut st))
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_require(c: &mut Criterion) {
+    let image = image();
+    let trie = build_trie(&image);
+    let tree = build_tree(&image);
+
+    // stat -> open -> read to EOF -> close, the shape of a single `require`.
+    let mut group = c.benchmark_group("require");
+    group.bench_function("trie", |b| {
+        b.iter(|| {
+            let comps = split(black_box(DEEP));
+            let mut st: libc::stat = unsafe { std::mem::zeroed() };
+            trie.stat(&comps, &mut st);
+            let fd = trie.open(&comps).unwrap();
+            let mut buf = [0u8; 8192];
+            while trie.read(fd, &mut buf).unwrap_or(0) > 0 {}
+            trie.close(fd);
+            unsafe { libc::close(fd) };
+        })
+    });
+    group.bench_function("tree", |b| {
+        b.iter(|| {
+            let path = black_box(DEEP.as_bytes());
+            let mut st: libc::stat = unsafe { std::mem::zeroed() };
+            tree.stat(path, &mut st);
+            let fd = tree.open(path).unwrap();
+            let mut buf = [0u8; 8192];
+            while tree.read(fd, &mut buf).unwrap_or(0) > 0 {}
+            tree.close(fd);
+            unsafe { libc::close(fd) };
+        })
+    });
+    group.finish();
+}
+
+fn bench_readdir(c: &mut Criterion) {
+    let image = image();
+    let trie = build_trie(&image);
+    let tree = build_tree(&image);
+
+    let dirs = [
+        ("app_models", "/app/models"),
+        ("gem_lib", "/vendor/bundle/ruby/3.2.0/gems/rails/lib"),
+        ("gems", "/vendor/bundle/ruby/3.2.0/gems"),
+    ];
+
+    let mut group = c.benchmark_group("readdir");
+    group.sample_size(20);
+    for (name, path) in dirs {
+        group.bench_function(format!("trie/{name}"), |b| {
+            let comps = split(path);
+            b.iter(|| {
+                let mut dir = trie.opendir(black_box(&comps)).unwrap();
+                let mut n = 0u32;
+                loop {
+                    match trie.readdir(&mut dir) {
+                        Some(p) if !p.is_null() => {
+                            n += 1;
+                            // The trie allocates a dirent per entry; `glue`
+                            // never frees it, so free it here to bench the
+                            // work rather than the leak.
+                            unsafe { drop(Box::from_raw(p)) };
+                        }
+                        _ => break,
+                    }
+                }
+                let fd = dir.fd;
+                trie.closedir(&dir);
+                unsafe { libc::close(fd) };
+                n
+            })
+        });
+        group.bench_function(format!("tree/{name}"), |b| {
+            b.iter(|| {
+                let mut dir = tree.opendir(black_box(path.as_bytes())).unwrap();
+                let mut n = 0u32;
+                loop {
+                    match tree.readdir(&mut dir) {
+                        Some(p) if !p.is_null() => n += 1,
+                        _ => break,
+                    }
+                }
+                let fd = dir.fd;
+                tree.closedir(&dir);
+                unsafe { libc::close(fd) };
+                n
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_build,
+    bench_stat,
+    bench_require,
+    bench_readdir
+);
+criterion_main!(benches);

--- a/kompo_tree/benches/tree_bench.rs
+++ b/kompo_tree/benches/tree_bench.rs
@@ -15,7 +15,7 @@ static MEDIUM: &[u8] = &[b'#'; 4096];
 static LARGE: &[u8] = &[b'#'; 32768];
 
 fn leak(s: String) -> &'static str {
-    Box::leak(s.into_boxed_str())
+    s.leak()
 }
 
 /// A Rails app with its bundled gems, emitted gem by gem like the real image.
@@ -157,16 +157,11 @@ fn build_trie(image: &[(&'static str, &'static [u8])]) -> kompo_storage::Fs<'sta
 fn blobs(
     image: &[(&'static str, &'static [u8])],
 ) -> (&'static [u8], &'static [u8], &'static [u64]) {
-    let mut paths = Vec::new();
-    let mut files = Vec::new();
-    let mut offsets = vec![0u64];
+    let mut builder = kompo_tree::FsBuilder::new();
     for (path, data) in image {
-        paths.extend_from_slice(path.as_bytes());
-        paths.push(0);
-        files.extend_from_slice(data);
-        offsets.push(files.len() as u64);
+        builder.push(path, data);
     }
-    (Vec::leak(paths), Vec::leak(files), Vec::leak(offsets))
+    builder.leak_parts()
 }
 
 fn build_tree(image: &[(&'static str, &'static [u8])]) -> kompo_tree::Fs<'static> {

--- a/kompo_tree/src/lib.rs
+++ b/kompo_tree/src/lib.rs
@@ -227,7 +227,12 @@ impl<'a> Fs<'a> {
 
     // -- files ------------------------------------------------------------
 
-    fn open_node(&self, id: NodeId) -> Option<i32> {
+    /// Open a node that has already been resolved.
+    ///
+    /// `open` is the usual entry point; this one exists so a caller that has to
+    /// inspect the node first -- `O_DIRECTORY` needs to tell ENOTDIR from
+    /// ENOENT -- does not have to resolve the path a second time.
+    pub fn open_node(&self, id: NodeId) -> Option<i32> {
         // A real fd, so it can never collide with one the process already has.
         let fd = unsafe { libc::dup(0) };
         if fd < 0 {

--- a/kompo_tree/src/lib.rs
+++ b/kompo_tree/src/lib.rs
@@ -39,7 +39,6 @@ pub const DEV: libc::dev_t = libc::makedev(2222, 0);
 /// way while the node id below it stays dense and collision-free.
 pub const INO_BASE: u64 = 1 << 62;
 
-/// Inode number reported for a node.
 #[inline]
 pub const fn inode(id: NodeId) -> u64 {
     INO_BASE | id as u64
@@ -142,7 +141,6 @@ impl<'a> Fs<'a> {
         }
     }
 
-    /// Is this node a directory?
     #[inline]
     pub fn is_dir(&self, id: NodeId) -> bool {
         self.tree.is_dir(id)
@@ -155,7 +153,6 @@ impl<'a> Fs<'a> {
 
     // -- lookup -----------------------------------------------------------
 
-    /// Resolve an absolute path to a node.
     #[inline]
     pub fn lookup(&self, path: &[u8]) -> Option<NodeId> {
         self.tree.lookup(path)
@@ -238,10 +235,10 @@ impl<'a> Fs<'a> {
     }
 
     pub fn read(&self, fd: i32, buf: &mut [u8]) -> Option<isize> {
-        // Claim a range under the lock, then copy outside it. File bodies are
-        // immutable, so only the cursor needs protecting, and mmap routes
-        // whole-file reads through here -- holding the table exclusively
-        // across a multi-megabyte copy would stall every other packed fd.
+        // File bodies are immutable, so only the cursor needs the lock. mmap
+        // routes whole-file reads through here, and holding the table
+        // exclusively across a multi-megabyte copy would stall every other
+        // packed fd for the duration.
         let (data, offset, n) = {
             let mut fds = self.fds.write().ok()?;
             let open = fds.get_mut(fd)?;

--- a/kompo_tree/src/lib.rs
+++ b/kompo_tree/src/lib.rs
@@ -6,7 +6,10 @@
 //!
 //! * paths are taken as raw bytes rather than pre-split components, because
 //!   every caller in `kompo_fs` already has an absolute path in hand and the
-//!   splitting was pure overhead;
+//!   splitting was pure overhead. It also sidesteps the `to_str().unwrap()` in
+//!   `kompo_fs::glue`, which panics on a path that is not valid UTF-8 -- the
+//!   generator does not validate encoding, and a gem shipping a Latin-1 or
+//!   Shift_JIS filename is enough to hit it;
 //! * a directory knows its entries as a contiguous range, so `readdir` neither
 //!   searches nor allocates.
 //!
@@ -207,6 +210,11 @@ impl<'a> Fs<'a> {
     }
 
     /// The image holds no symlinks, so this is `stat`.
+    ///
+    /// The generator skips symlinked directories outright and copies a
+    /// symlinked file's target bytes under the link's own path, so nothing in
+    /// the image is a link. One file can appear under two paths that way; those
+    /// are two nodes with two inodes, as they are in `kompo_storage`.
     pub fn lstat(&self, path: &[u8], st: &mut libc::stat) -> Option<i32> {
         self.stat(path, st)
     }

--- a/kompo_tree/src/lib.rs
+++ b/kompo_tree/src/lib.rs
@@ -238,17 +238,25 @@ impl<'a> Fs<'a> {
     }
 
     pub fn read(&self, fd: i32, buf: &mut [u8]) -> Option<isize> {
-        let mut fds = self.fds.write().ok()?;
-        let open = fds.get_mut(fd)?;
-        // A directory has no body, so `data` is what rejects it.
-        let data = self.tree.data(open.node)?;
-        let offset = open.offset as usize;
-        if offset >= data.len() {
-            return Some(0);
-        }
-        let n = (data.len() - offset).min(buf.len());
+        // Claim a range under the lock, then copy outside it. File bodies are
+        // immutable, so only the cursor needs protecting, and mmap routes
+        // whole-file reads through here -- holding the table exclusively
+        // across a multi-megabyte copy would stall every other packed fd.
+        let (data, offset, n) = {
+            let mut fds = self.fds.write().ok()?;
+            let open = fds.get_mut(fd)?;
+            // A directory has no body, so `data` is what rejects it.
+            let data = self.tree.data(open.node)?;
+            let offset = open.offset as usize;
+            if offset >= data.len() {
+                return Some(0);
+            }
+            let n = (data.len() - offset).min(buf.len());
+            open.offset += n as u64;
+            (data, offset, n)
+        };
+
         buf[..n].copy_from_slice(&data[offset..offset + n]);
-        open.offset += n as u64;
         Some(n as isize)
     }
 
@@ -299,7 +307,6 @@ impl<'a> Fs<'a> {
     }
 
     fn fill_dirent(&self, id: NodeId, next_offset: u64, out: &mut libc::dirent) {
-        *out = unsafe { std::mem::zeroed() };
         out.d_ino = inode(id);
         out.d_type = if self.tree.is_dir(id) {
             libc::DT_DIR
@@ -309,11 +316,14 @@ impl<'a> Fs<'a> {
         out.d_reclen = size_of::<libc::dirent>() as _;
 
         let name = self.tree.name(id);
-        // Leave room for the terminator; the buffer is already zeroed.
         let n = name.len().min(out.d_name.len() - 1);
         for (slot, &byte) in out.d_name.iter_mut().zip(&name[..n]) {
             *slot = byte as _;
         }
+        // Only the terminator needs writing. `FsDir` zeroes the buffer once, so
+        // anything past it is a stale name rather than uninitialised memory --
+        // the same thing readdir(3) leaves behind.
+        out.d_name[n] = 0;
 
         #[cfg(target_os = "linux")]
         {

--- a/kompo_tree/src/lib.rs
+++ b/kompo_tree/src/lib.rs
@@ -1,0 +1,801 @@
+//! Path index and file table for the embedded filesystem.
+//!
+//! This is a candidate replacement for the trie in `kompo_storage`, built
+//! around a flat node arena instead of a LOUDS trie. It exposes the same
+//! operations, with two deliberate differences:
+//!
+//! * paths are taken as raw bytes rather than pre-split components, because
+//!   every caller in `kompo_fs` already has an absolute path in hand and the
+//!   splitting was pure overhead;
+//! * a directory knows its entries as a contiguous range, so `readdir` neither
+//!   searches nor allocates.
+//!
+//! Inode numbers are node ids offset by [`INO_BASE`]. That makes them unique by
+//! construction rather than by hash luck, and keeps them clear of the range a
+//! real filesystem hands out -- the VFS is mixed with the real one, and while
+//! `st_dev` is what actually separates the two, `struct dirent` carries a bare
+//! `d_ino` with no device field to qualify it.
+
+mod tree;
+
+pub use tree::{NodeId, ROOT, Tree};
+
+use std::sync::RwLock;
+
+/// Fake device number, shared with `kompo_storage` so both report the same
+/// `st_dev`. Major 2222 is outside the range Linux hands out, and outside the
+/// anonymous major 0 that tmpfs and overlayfs use.
+pub const DEV: libc::dev_t = libc::makedev(2222, 0);
+
+/// Inode numbers are `INO_BASE | node_id`.
+///
+/// Real filesystems allocate inode numbers from the bottom of the range: ext4
+/// caps at 32 bits, and XFS and btrfs stay far below this bit for any
+/// achievable filesystem size. Setting bit 62 keeps virtual inodes out of the
+/// way while the node id below it stays dense and collision-free.
+pub const INO_BASE: u64 = 1 << 62;
+
+/// Inode number reported for a node.
+#[inline]
+pub const fn inode(id: NodeId) -> u64 {
+    INO_BASE | id as u64
+}
+
+#[derive(Clone, Copy, Debug)]
+struct OpenFile {
+    node: NodeId,
+    offset: u64,
+    is_dir: bool,
+}
+
+/// Open file descriptors, indexed directly by fd.
+///
+/// The fds come from `dup(0)`, so they are real, unique, and dense -- a plain
+/// vector beats a hash map here.
+#[derive(Default)]
+struct FdTable {
+    slots: Vec<Option<OpenFile>>,
+}
+
+impl FdTable {
+    fn insert(&mut self, fd: i32, open: OpenFile) {
+        if fd < 0 {
+            return;
+        }
+        let i = fd as usize;
+        if i >= self.slots.len() {
+            self.slots.resize(i + 1, None);
+        }
+        self.slots[i] = Some(open);
+    }
+
+    fn get(&self, fd: i32) -> Option<&OpenFile> {
+        if fd < 0 {
+            return None;
+        }
+        self.slots.get(fd as usize)?.as_ref()
+    }
+
+    fn get_mut(&mut self, fd: i32) -> Option<&mut OpenFile> {
+        if fd < 0 {
+            return None;
+        }
+        self.slots.get_mut(fd as usize)?.as_mut()
+    }
+
+    fn remove(&mut self, fd: i32) -> Option<OpenFile> {
+        if fd < 0 {
+            return None;
+        }
+        self.slots.get_mut(fd as usize)?.take()
+    }
+
+    fn open_fds(&self) -> impl Iterator<Item = i32> + '_ {
+        self.slots
+            .iter()
+            .enumerate()
+            .filter_map(|(i, slot)| slot.as_ref().map(|_| i as i32))
+    }
+}
+
+/// An open directory handle.
+///
+/// The `dirent` lives here rather than being allocated per call, which matches
+/// what POSIX promises callers (`readdir` returns storage owned by the `DIR`)
+/// and means nothing has to be freed.
+pub struct FsDir {
+    pub fd: i32,
+    node: NodeId,
+    offset: u32,
+    entry: libc::dirent,
+}
+
+impl FsDir {
+    fn new(fd: i32, node: NodeId) -> Self {
+        Self {
+            fd,
+            node,
+            offset: 0,
+            entry: unsafe { std::mem::zeroed() },
+        }
+    }
+}
+
+impl std::fmt::Debug for FsDir {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FsDir")
+            .field("fd", &self.fd)
+            .field("node", &self.node)
+            .field("offset", &self.offset)
+            .finish_non_exhaustive()
+    }
+}
+
+pub struct Fs<'a> {
+    tree: Tree<'a>,
+    fds: RwLock<FdTable>,
+    uid: libc::uid_t,
+    gid: libc::gid_t,
+}
+
+impl<'a> Fs<'a> {
+    /// Build from the embedded blobs.
+    ///
+    /// `paths` is the NUL separated `PATHS` blob, `files` is `FILES` (or the
+    /// decompressed buffer), and `file_offsets` is `FILES_SIZES`: one more
+    /// entry than there are paths.
+    pub fn new(paths: &'a [u8], files: &'a [u8], file_offsets: &'a [u64]) -> Self {
+        Self {
+            tree: Tree::build(paths, files, file_offsets),
+            fds: RwLock::new(FdTable::default()),
+            // Constant for the process, and a syscall each on some platforms,
+            // so it is read once instead of on every stat.
+            uid: unsafe { libc::getuid() },
+            gid: unsafe { libc::getgid() },
+        }
+    }
+
+    pub fn tree(&self) -> &Tree<'a> {
+        &self.tree
+    }
+
+    // -- lookup -----------------------------------------------------------
+
+    /// Resolve an absolute path to a node.
+    #[inline]
+    pub fn lookup(&self, path: &[u8]) -> Option<NodeId> {
+        self.tree.lookup(path)
+    }
+
+    pub fn is_dir_exists_from_path(&self, path: &[u8]) -> bool {
+        self.tree
+            .lookup(path)
+            .is_some_and(|id| self.tree.is_dir(id))
+    }
+
+    // -- metadata ---------------------------------------------------------
+
+    fn fill_stat(&self, id: NodeId, st: &mut libc::stat) -> Option<()> {
+        if !self.tree.exists(id) {
+            return None;
+        }
+        // Zero first: unset and padding fields then read as 0 rather than
+        // whatever the caller's buffer happened to hold.
+        *st = unsafe { std::mem::zeroed() };
+        st.st_dev = DEV;
+        st.st_ino = inode(id);
+        st.st_nlink = 1;
+        st.st_uid = self.uid;
+        st.st_gid = self.gid;
+        st.st_blksize = 4096;
+
+        if self.tree.is_dir(id) {
+            st.st_mode = libc::S_IFDIR | 0o555;
+            st.st_size = 1;
+        } else {
+            let len = self.tree.data(id).map_or(0, <[u8]>::len);
+            st.st_mode = libc::S_IFREG | 0o444;
+            st.st_size = len as _;
+            st.st_blocks = (len.div_ceil(512).div_ceil(8) * 8) as _;
+        }
+        Some(())
+    }
+
+    pub fn stat(&self, path: &[u8], st: &mut libc::stat) -> Option<i32> {
+        self.fill_stat(self.tree.lookup(path)?, st)?;
+        Some(0)
+    }
+
+    /// The image holds no symlinks, so this is `stat`.
+    pub fn lstat(&self, path: &[u8], st: &mut libc::stat) -> Option<i32> {
+        self.stat(path, st)
+    }
+
+    pub fn fstat(&self, fd: i32, st: &mut libc::stat) -> Option<i32> {
+        let node = self.fds.read().ok()?.get(fd)?.node;
+        self.fill_stat(node, st)?;
+        Some(0)
+    }
+
+    // -- files ------------------------------------------------------------
+
+    fn open_node(&self, id: NodeId) -> Option<i32> {
+        // A real fd, so it can never collide with one the process already has.
+        let fd = unsafe { libc::dup(0) };
+        if fd < 0 {
+            return None;
+        }
+        let Ok(mut fds) = self.fds.write() else {
+            unsafe { libc::close(fd) };
+            return None;
+        };
+        fds.insert(
+            fd,
+            OpenFile {
+                node: id,
+                offset: 0,
+                is_dir: self.tree.is_dir(id),
+            },
+        );
+        Some(fd)
+    }
+
+    pub fn open(&self, path: &[u8]) -> Option<i32> {
+        self.open_node(self.tree.lookup(path)?)
+    }
+
+    /// Same as [`Fs::open`]; the caller resolves `dirfd` before calling.
+    pub fn open_at(&self, path: &[u8]) -> Option<i32> {
+        self.open(path)
+    }
+
+    pub fn read(&self, fd: i32, buf: &mut [u8]) -> Option<isize> {
+        let mut fds = self.fds.write().ok()?;
+        let open = fds.get_mut(fd)?;
+        if open.is_dir {
+            return None;
+        }
+        let data = self.tree.data(open.node)?;
+        let offset = open.offset as usize;
+        if offset >= data.len() {
+            return Some(0);
+        }
+        let n = (data.len() - offset).min(buf.len());
+        buf[..n].copy_from_slice(&data[offset..offset + n]);
+        open.offset += n as u64;
+        Some(n as isize)
+    }
+
+    pub fn close(&self, fd: i32) -> i32 {
+        if let Ok(mut fds) = self.fds.write() {
+            fds.remove(fd);
+        }
+        0
+    }
+
+    /// Pointer to a file body, for callers that map it rather than read it.
+    ///
+    /// Unlike `kompo_storage::Fs::file_read` this reports a missing path as
+    /// `None` instead of panicking.
+    pub fn file_read(&self, path: &[u8]) -> Option<*const u8> {
+        self.tree.data(self.tree.lookup(path)?).map(<[u8]>::as_ptr)
+    }
+
+    pub fn is_fd_exists(&self, fd: i32) -> bool {
+        self.fds.read().is_ok_and(|fds| fds.get(fd).is_some())
+    }
+
+    // -- directories ------------------------------------------------------
+
+    pub fn opendir(&self, path: &[u8]) -> Option<FsDir> {
+        let id = self.tree.lookup(path)?;
+        if !self.tree.is_dir(id) {
+            return None;
+        }
+        Some(FsDir::new(self.open_node(id)?, id))
+    }
+
+    pub fn fdopendir(&self, fd: i32) -> Option<FsDir> {
+        let open = *self.fds.read().ok()?.get(fd)?;
+        if !open.is_dir {
+            return None;
+        }
+        Some(FsDir::new(fd, open.node))
+    }
+
+    /// Next entry, or a null pointer at end of directory.
+    ///
+    /// The returned pointer borrows `dir` and stays valid until the next call,
+    /// exactly like `readdir(3)`. Callers must not free it.
+    pub fn readdir(&self, dir: &mut FsDir) -> Option<*mut libc::dirent> {
+        if !self.is_fd_exists(dir.fd) {
+            return None;
+        }
+        let Some(child) = self.tree.child_at(dir.node, dir.offset) else {
+            return Some(std::ptr::null_mut());
+        };
+        dir.offset += 1;
+        let next = u64::from(dir.offset);
+        self.fill_dirent(child, next, &mut dir.entry);
+        Some(&raw mut dir.entry)
+    }
+
+    fn fill_dirent(&self, id: NodeId, next_offset: u64, out: &mut libc::dirent) {
+        *out = unsafe { std::mem::zeroed() };
+        out.d_ino = inode(id);
+        out.d_type = if self.tree.is_dir(id) {
+            libc::DT_DIR
+        } else {
+            libc::DT_REG
+        };
+        out.d_reclen = size_of::<libc::dirent>() as _;
+
+        let name = self.tree.name(id);
+        // Leave room for the terminator; the buffer is already zeroed.
+        let n = name.len().min(out.d_name.len() - 1);
+        for (slot, &byte) in out.d_name.iter_mut().zip(&name[..n]) {
+            *slot = byte as _;
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            out.d_off = next_offset as _;
+        }
+        #[cfg(target_os = "macos")]
+        {
+            out.d_seekoff = next_offset;
+            out.d_namlen = n as _;
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        let _ = next_offset;
+    }
+
+    pub fn closedir(&self, dir: &FsDir) -> i32 {
+        self.close(dir.fd)
+    }
+
+    pub fn rewinddir(&self, dir: &mut FsDir) {
+        dir.offset = 0;
+    }
+
+    pub fn is_dir_exists(&self, dir: &FsDir) -> bool {
+        self.is_fd_exists(dir.fd)
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn getattrlist(
+        &self,
+        path: &[u8],
+        attr_list: &libc::attrlist,
+        attr_buf: *mut libc::c_void,
+        attr_buf_size: usize,
+    ) -> Option<i32> {
+        #[repr(C)]
+        struct AttrBufNameAndObjType {
+            length: u32,
+            name_ref: libc::attrreference_t,
+            obj_type: u32,
+        }
+
+        if attr_list.commonattr != (libc::ATTR_CMN_NAME | libc::ATTR_CMN_OBJTYPE) {
+            return None;
+        }
+
+        let id = self.tree.lookup(path)?;
+        let obj_type: u32 = if self.tree.is_dir(id) { 2 } else { 1 }; // VDIR : VREG
+        let basename = self.tree.name(id);
+        let basename_len = basename.len() + 1;
+
+        let header_size = size_of::<AttrBufNameAndObjType>();
+        let total_size = header_size + basename_len;
+        if total_size > attr_buf_size {
+            return None;
+        }
+
+        let result = AttrBufNameAndObjType {
+            length: total_size as u32,
+            name_ref: libc::attrreference_t {
+                attr_dataoffset: (header_size
+                    - std::mem::offset_of!(AttrBufNameAndObjType, name_ref))
+                    as i32,
+                attr_length: basename_len as u32,
+            },
+            obj_type,
+        };
+
+        unsafe {
+            std::ptr::write(attr_buf as *mut AttrBufNameAndObjType, result);
+            let name_ptr = (attr_buf as *mut u8).add(header_size);
+            std::ptr::copy_nonoverlapping(basename.as_ptr(), name_ptr, basename.len());
+            *name_ptr.add(basename.len()) = 0;
+        }
+
+        Some(0)
+    }
+}
+
+impl Drop for Fs<'_> {
+    fn drop(&mut self) {
+        if let Ok(fds) = self.fds.read() {
+            for fd in fds.open_fds() {
+                unsafe { libc::close(fd) };
+            }
+        }
+    }
+}
+
+/// Assembles the blobs an [`Fs`] is built from, for tests and benchmarks.
+///
+/// The real filesystem is built from static data linked into the binary; this
+/// leaks its buffers to reach the same `'static` lifetime.
+pub struct FsBuilder {
+    paths: Vec<u8>,
+    files: Vec<u8>,
+    offsets: Vec<u64>,
+}
+
+impl Default for FsBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FsBuilder {
+    pub fn new() -> Self {
+        Self {
+            paths: Vec::new(),
+            files: Vec::new(),
+            offsets: vec![0],
+        }
+    }
+
+    pub fn push(&mut self, path: impl AsRef<[u8]>, data: impl AsRef<[u8]>) -> &mut Self {
+        self.paths.extend_from_slice(path.as_ref());
+        self.paths.push(0);
+        self.files.extend_from_slice(data.as_ref());
+        self.offsets.push(self.files.len() as u64);
+        self
+    }
+
+    /// Leak the blobs and build. Intended for tests and benchmarks.
+    pub fn leak(self) -> Fs<'static> {
+        Fs::new(
+            Vec::leak(self.paths),
+            Vec::leak(self.files),
+            Vec::leak(self.offsets),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fs() -> Fs<'static> {
+        let mut b = FsBuilder::new();
+        b.push("/usr/bin/ls", b"ls_content");
+        b.push("/usr/bin/cat", b"cat_content_here");
+        b.push("/usr/bin/hoge/fuga", b"hoge_fuga_content");
+        b.push("/usr/bin/fuga", b"fuga_content");
+        b.push("/usr/empty", b"");
+        b.leak()
+    }
+
+    fn zeroed_stat() -> libc::stat {
+        unsafe { std::mem::zeroed() }
+    }
+
+    fn drain(fs: &Fs, dir: &mut FsDir) -> Vec<String> {
+        let mut out = Vec::new();
+        loop {
+            let entry = fs.readdir(dir).expect("readdir on a live handle");
+            if entry.is_null() {
+                break;
+            }
+            let name: Vec<u8> = unsafe { &*entry }
+                .d_name
+                .iter()
+                .take_while(|&&c| c != 0)
+                .map(|&c| c as u8)
+                .collect();
+            out.push(String::from_utf8_lossy(&name).into_owned());
+        }
+        out
+    }
+
+    #[test]
+    fn open_and_read_a_file() {
+        let fs = fs();
+        let fd = fs.open(b"/usr/bin/ls").unwrap();
+        let mut buf = [0u8; 128];
+        assert_eq!(fs.read(fd, &mut buf), Some(10));
+        assert_eq!(&buf[..10], b"ls_content");
+        // Second read is EOF.
+        assert_eq!(fs.read(fd, &mut buf), Some(0));
+        assert_eq!(fs.close(fd), 0);
+        assert!(!fs.is_fd_exists(fd));
+        unsafe { libc::close(fd) };
+    }
+
+    #[test]
+    fn read_in_chunks_advances_the_offset() {
+        let fs = fs();
+        let fd = fs.open(b"/usr/bin/cat").unwrap();
+        let mut buf = [0u8; 4];
+        assert_eq!(fs.read(fd, &mut buf), Some(4));
+        assert_eq!(&buf, b"cat_");
+        assert_eq!(fs.read(fd, &mut buf), Some(4));
+        assert_eq!(&buf, b"cont");
+        fs.close(fd);
+        unsafe { libc::close(fd) };
+    }
+
+    #[test]
+    fn empty_file_reads_zero_bytes() {
+        let fs = fs();
+        let fd = fs.open(b"/usr/empty").unwrap();
+        let mut buf = [0u8; 8];
+        assert_eq!(fs.read(fd, &mut buf), Some(0));
+        fs.close(fd);
+        unsafe { libc::close(fd) };
+    }
+
+    #[test]
+    fn open_and_read_reject_bad_input() {
+        let fs = fs();
+        assert_eq!(fs.open(b"/usr/bin/nonexistent"), None);
+        assert_eq!(fs.read(9999, &mut [0u8; 8]), None);
+
+        // A directory opens, but does not read.
+        let fd = fs.open(b"/usr/bin").unwrap();
+        assert_eq!(fs.read(fd, &mut [0u8; 8]), None);
+        fs.close(fd);
+        unsafe { libc::close(fd) };
+    }
+
+    #[test]
+    fn concurrent_opens_get_independent_offsets() {
+        let fs = fs();
+        let a = fs.open(b"/usr/bin/ls").unwrap();
+        let b = fs.open(b"/usr/bin/ls").unwrap();
+        assert_ne!(a, b);
+
+        let mut buf = [0u8; 2];
+        fs.read(a, &mut buf).unwrap();
+        assert_eq!(&buf, b"ls");
+        // `b` is untouched and still at the start.
+        fs.read(b, &mut buf).unwrap();
+        assert_eq!(&buf, b"ls");
+
+        fs.close(a);
+        assert!(!fs.is_fd_exists(a));
+        assert!(fs.is_fd_exists(b));
+        fs.close(b);
+        unsafe {
+            libc::close(a);
+            libc::close(b);
+        }
+    }
+
+    #[test]
+    fn stat_reports_files_and_directories() {
+        let fs = fs();
+        let mut st = zeroed_stat();
+
+        assert_eq!(fs.stat(b"/usr/bin/ls", &mut st), Some(0));
+        assert_eq!(st.st_size, 10);
+        assert_eq!(st.st_mode & libc::S_IFMT, libc::S_IFREG);
+        assert_eq!(st.st_dev, DEV);
+
+        assert_eq!(fs.stat(b"/usr/bin", &mut st), Some(0));
+        assert_eq!(st.st_mode & libc::S_IFMT, libc::S_IFDIR);
+        assert_eq!(st.st_dev, DEV);
+
+        assert_eq!(fs.stat(b"/nonexistent", &mut st), None);
+        assert_eq!(fs.lstat(b"/usr/bin/ls", &mut st), Some(0));
+    }
+
+    #[test]
+    fn fstat_matches_stat() {
+        let fs = fs();
+        let mut by_path = zeroed_stat();
+        fs.stat(b"/usr/bin/cat", &mut by_path).unwrap();
+
+        let fd = fs.open(b"/usr/bin/cat").unwrap();
+        let mut by_fd = zeroed_stat();
+        assert_eq!(fs.fstat(fd, &mut by_fd), Some(0));
+
+        assert_eq!(by_fd.st_ino, by_path.st_ino);
+        assert_eq!(by_fd.st_size, 16);
+        assert_eq!(fs.fstat(9999, &mut by_fd), None);
+
+        fs.close(fd);
+        unsafe { libc::close(fd) };
+    }
+
+    #[test]
+    fn stat_overwrites_stale_buffer_contents() {
+        let fs = fs();
+        let mut st = zeroed_stat();
+        st.st_size = 12345;
+        st.st_mtime = 999;
+        fs.stat(b"/usr/empty", &mut st).unwrap();
+        assert_eq!(st.st_size, 0);
+        assert_eq!(st.st_mtime, 0);
+    }
+
+    #[test]
+    fn inodes_are_unique_and_out_of_the_real_range() {
+        let fs = fs();
+        let paths: [&[u8]; 7] = [
+            b"/",
+            b"/usr",
+            b"/usr/bin",
+            b"/usr/bin/ls",
+            b"/usr/bin/cat",
+            b"/usr/bin/hoge",
+            b"/usr/bin/hoge/fuga",
+        ];
+        let mut seen = std::collections::HashSet::new();
+        for p in paths {
+            let mut st = zeroed_stat();
+            fs.stat(p, &mut st).unwrap();
+            assert!(st.st_ino >= INO_BASE, "{:?} got {:#x}", p, st.st_ino);
+            assert!(seen.insert(st.st_ino), "duplicate inode for {:?}", p);
+        }
+    }
+
+    #[test]
+    fn the_same_file_keeps_one_identity_across_spellings() {
+        let fs = fs();
+        let mut direct = zeroed_stat();
+        let mut indirect = zeroed_stat();
+        fs.stat(b"/usr/bin/ls", &mut direct).unwrap();
+        fs.stat(b"/usr/bin/hoge/../ls", &mut indirect).unwrap();
+        assert_eq!(direct.st_ino, indirect.st_ino);
+        assert_eq!(direct.st_dev, indirect.st_dev);
+    }
+
+    #[test]
+    fn opendir_lists_entries_once() {
+        let fs = fs();
+        let mut dir = fs.opendir(b"/usr/bin").unwrap();
+        let entries = drain(&fs, &mut dir);
+        assert_eq!(entries, vec!["cat", "fuga", "hoge", "ls"]);
+
+        // Past the end stays at the end.
+        assert!(fs.readdir(&mut dir).unwrap().is_null());
+
+        let fd = dir.fd;
+        assert_eq!(fs.closedir(&dir), 0);
+        assert!(!fs.is_fd_exists(fd));
+        unsafe { libc::close(fd) };
+    }
+
+    #[test]
+    fn readdir_reports_entry_types_and_inodes() {
+        let fs = fs();
+        let mut dir = fs.opendir(b"/usr/bin").unwrap();
+        let mut seen = Vec::new();
+        loop {
+            let e = fs.readdir(&mut dir).unwrap();
+            if e.is_null() {
+                break;
+            }
+            let e = unsafe { &*e };
+            let name: Vec<u8> = e
+                .d_name
+                .iter()
+                .take_while(|&&c| c != 0)
+                .map(|&c| c as u8)
+                .collect();
+            seen.push((
+                String::from_utf8_lossy(&name).into_owned(),
+                e.d_type,
+                e.d_ino,
+            ));
+        }
+
+        let hoge = seen.iter().find(|(n, ..)| n == "hoge").unwrap();
+        assert_eq!(hoge.1, libc::DT_DIR);
+        let ls = seen.iter().find(|(n, ..)| n == "ls").unwrap();
+        assert_eq!(ls.1, libc::DT_REG);
+
+        // d_ino must agree with what stat reports for the same entry.
+        let mut st = zeroed_stat();
+        fs.stat(b"/usr/bin/ls", &mut st).unwrap();
+        assert_eq!(ls.2, st.st_ino);
+
+        let fd = dir.fd;
+        fs.closedir(&dir);
+        unsafe { libc::close(fd) };
+    }
+
+    #[test]
+    fn rewinddir_restarts_the_listing() {
+        let fs = fs();
+        let mut dir = fs.opendir(b"/usr/bin").unwrap();
+        let first = drain(&fs, &mut dir);
+        fs.rewinddir(&mut dir);
+        let second = drain(&fs, &mut dir);
+        assert_eq!(first, second);
+
+        let fd = dir.fd;
+        fs.closedir(&dir);
+        unsafe { libc::close(fd) };
+    }
+
+    #[test]
+    fn opendir_rejects_files_and_missing_paths() {
+        let fs = fs();
+        assert!(fs.opendir(b"/usr/bin/ls").is_none());
+        assert!(fs.opendir(b"/nonexistent").is_none());
+        assert!(fs.is_dir_exists_from_path(b"/usr/bin"));
+        assert!(!fs.is_dir_exists_from_path(b"/usr/bin/ls"));
+        assert!(!fs.is_dir_exists_from_path(b"/nonexistent"));
+    }
+
+    #[test]
+    fn fdopendir_accepts_only_directory_fds() {
+        let fs = fs();
+        let dir_fd = fs.open(b"/usr/bin").unwrap();
+        let dir = fs.fdopendir(dir_fd).unwrap();
+        assert_eq!(dir.fd, dir_fd);
+        assert!(fs.is_dir_exists(&dir));
+
+        let file_fd = fs.open(b"/usr/bin/ls").unwrap();
+        assert!(fs.fdopendir(file_fd).is_none());
+
+        fs.close(dir_fd);
+        fs.close(file_fd);
+        unsafe {
+            libc::close(dir_fd);
+            libc::close(file_fd);
+        }
+    }
+
+    #[test]
+    fn readdir_on_a_closed_handle_reports_failure() {
+        let fs = fs();
+        let mut dir = fs.opendir(b"/usr/bin").unwrap();
+        let fd = dir.fd;
+        fs.closedir(&dir);
+        assert!(fs.readdir(&mut dir).is_none());
+        unsafe { libc::close(fd) };
+    }
+
+    #[test]
+    fn file_read_returns_the_body() {
+        let fs = fs();
+        let ptr = fs.file_read(b"/usr/bin/ls").unwrap();
+        let body = unsafe { std::slice::from_raw_parts(ptr, 10) };
+        assert_eq!(body, b"ls_content");
+        assert!(fs.file_read(b"/nonexistent").is_none());
+        // A directory has no body.
+        assert!(fs.file_read(b"/usr/bin").is_none());
+    }
+
+    #[test]
+    fn shared_across_threads() {
+        let fs = std::sync::Arc::new(fs());
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let fs = std::sync::Arc::clone(&fs);
+                std::thread::spawn(move || {
+                    for _ in 0..200 {
+                        let mut st = zeroed_stat();
+                        assert_eq!(fs.stat(b"/usr/bin/ls", &mut st), Some(0));
+                        let fd = fs.open(b"/usr/bin/cat").unwrap();
+                        let mut buf = [0u8; 16];
+                        assert_eq!(fs.read(fd, &mut buf), Some(16));
+                        fs.close(fd);
+                        unsafe { libc::close(fd) };
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+    }
+}

--- a/kompo_tree/src/lib.rs
+++ b/kompo_tree/src/lib.rs
@@ -21,9 +21,10 @@
 
 mod tree;
 
-pub use tree::{NodeId, ROOT, Tree};
+pub use tree::{NodeId, path_count};
 
 use std::sync::RwLock;
+use tree::Tree;
 
 /// Fake device number, shared with `kompo_storage` so both report the same
 /// `st_dev`. Major 2222 is outside the range Linux hands out, and outside the
@@ -48,7 +49,6 @@ pub const fn inode(id: NodeId) -> u64 {
 struct OpenFile {
     node: NodeId,
     offset: u64,
-    is_dir: bool,
 }
 
 /// Open file descriptors, indexed directly by fd.
@@ -73,31 +73,15 @@ impl FdTable {
     }
 
     fn get(&self, fd: i32) -> Option<&OpenFile> {
-        if fd < 0 {
-            return None;
-        }
         self.slots.get(fd as usize)?.as_ref()
     }
 
     fn get_mut(&mut self, fd: i32) -> Option<&mut OpenFile> {
-        if fd < 0 {
-            return None;
-        }
         self.slots.get_mut(fd as usize)?.as_mut()
     }
 
     fn remove(&mut self, fd: i32) -> Option<OpenFile> {
-        if fd < 0 {
-            return None;
-        }
         self.slots.get_mut(fd as usize)?.take()
-    }
-
-    fn open_fds(&self) -> impl Iterator<Item = i32> + '_ {
-        self.slots
-            .iter()
-            .enumerate()
-            .filter_map(|(i, slot)| slot.as_ref().map(|_| i as i32))
     }
 }
 
@@ -158,8 +142,15 @@ impl<'a> Fs<'a> {
         }
     }
 
-    pub fn tree(&self) -> &Tree<'a> {
-        &self.tree
+    /// Is this node a directory?
+    #[inline]
+    pub fn is_dir(&self, id: NodeId) -> bool {
+        self.tree.is_dir(id)
+    }
+
+    /// Was every path in the blob spelled canonically? See [`Tree::build`].
+    pub fn paths_are_canonical(&self) -> bool {
+        self.tree.paths_are_canonical()
     }
 
     // -- lookup -----------------------------------------------------------
@@ -209,16 +200,6 @@ impl<'a> Fs<'a> {
         Some(0)
     }
 
-    /// The image holds no symlinks, so this is `stat`.
-    ///
-    /// The generator skips symlinked directories outright and copies a
-    /// symlinked file's target bytes under the link's own path, so nothing in
-    /// the image is a link. One file can appear under two paths that way; those
-    /// are two nodes with two inodes, as they are in `kompo_storage`.
-    pub fn lstat(&self, path: &[u8], st: &mut libc::stat) -> Option<i32> {
-        self.stat(path, st)
-    }
-
     pub fn fstat(&self, fd: i32, st: &mut libc::stat) -> Option<i32> {
         let node = self.fds.read().ok()?.get(fd)?.node;
         self.fill_stat(node, st)?;
@@ -247,7 +228,6 @@ impl<'a> Fs<'a> {
             OpenFile {
                 node: id,
                 offset: 0,
-                is_dir: self.tree.is_dir(id),
             },
         );
         Some(fd)
@@ -257,17 +237,10 @@ impl<'a> Fs<'a> {
         self.open_node(self.tree.lookup(path)?)
     }
 
-    /// Same as [`Fs::open`]; the caller resolves `dirfd` before calling.
-    pub fn open_at(&self, path: &[u8]) -> Option<i32> {
-        self.open(path)
-    }
-
     pub fn read(&self, fd: i32, buf: &mut [u8]) -> Option<isize> {
         let mut fds = self.fds.write().ok()?;
         let open = fds.get_mut(fd)?;
-        if open.is_dir {
-            return None;
-        }
+        // A directory has no body, so `data` is what rejects it.
         let data = self.tree.data(open.node)?;
         let offset = open.offset as usize;
         if offset >= data.len() {
@@ -286,14 +259,6 @@ impl<'a> Fs<'a> {
         0
     }
 
-    /// Pointer to a file body, for callers that map it rather than read it.
-    ///
-    /// Unlike `kompo_storage::Fs::file_read` this reports a missing path as
-    /// `None` instead of panicking.
-    pub fn file_read(&self, path: &[u8]) -> Option<*const u8> {
-        self.tree.data(self.tree.lookup(path)?).map(<[u8]>::as_ptr)
-    }
-
     pub fn is_fd_exists(&self, fd: i32) -> bool {
         self.fds.read().is_ok_and(|fds| fds.get(fd).is_some())
     }
@@ -310,7 +275,7 @@ impl<'a> Fs<'a> {
 
     pub fn fdopendir(&self, fd: i32) -> Option<FsDir> {
         let open = *self.fds.read().ok()?.get(fd)?;
-        if !open.is_dir {
+        if !self.tree.is_dir(open.node) {
             return None;
         }
         Some(FsDir::new(fd, open.node))
@@ -430,8 +395,10 @@ impl<'a> Fs<'a> {
 impl Drop for Fs<'_> {
     fn drop(&mut self) {
         if let Ok(fds) = self.fds.read() {
-            for fd in fds.open_fds() {
-                unsafe { libc::close(fd) };
+            for (fd, slot) in fds.slots.iter().enumerate() {
+                if slot.is_some() {
+                    unsafe { libc::close(fd as i32) };
+                }
             }
         }
     }
@@ -472,7 +439,15 @@ impl FsBuilder {
 
     /// Leak the blobs and build. Intended for tests and benchmarks.
     pub fn leak(self) -> Fs<'static> {
-        Fs::new(
+        let (paths, files, offsets) = self.leak_parts();
+
+        Fs::new(paths, files, offsets)
+    }
+
+    /// Leak the blobs without building, for a benchmark that wants to time
+    /// indexing them separately.
+    pub fn leak_parts(self) -> (&'static [u8], &'static [u8], &'static [u64]) {
+        (
             Vec::leak(self.paths),
             Vec::leak(self.files),
             Vec::leak(self.offsets),
@@ -483,6 +458,7 @@ impl FsBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::CStr;
 
     fn fs() -> Fs<'static> {
         let mut b = FsBuilder::new();
@@ -498,6 +474,17 @@ mod tests {
         unsafe { std::mem::zeroed() }
     }
 
+    /// Release both halves of an open: the table entry and the `dup(0)` fd.
+    fn release(fs: &Fs, fd: i32) {
+        fs.close(fd);
+        unsafe { libc::close(fd) };
+    }
+
+    fn entry_name(entry: &libc::dirent) -> String {
+        let name = unsafe { CStr::from_ptr(entry.d_name.as_ptr()) };
+        name.to_string_lossy().into_owned()
+    }
+
     fn drain(fs: &Fs, dir: &mut FsDir) -> Vec<String> {
         let mut out = Vec::new();
         loop {
@@ -505,13 +492,7 @@ mod tests {
             if entry.is_null() {
                 break;
             }
-            let name: Vec<u8> = unsafe { &*entry }
-                .d_name
-                .iter()
-                .take_while(|&&c| c != 0)
-                .map(|&c| c as u8)
-                .collect();
-            out.push(String::from_utf8_lossy(&name).into_owned());
+            out.push(entry_name(unsafe { &*entry }));
         }
         out
     }
@@ -539,8 +520,7 @@ mod tests {
         assert_eq!(&buf, b"cat_");
         assert_eq!(fs.read(fd, &mut buf), Some(4));
         assert_eq!(&buf, b"cont");
-        fs.close(fd);
-        unsafe { libc::close(fd) };
+        release(&fs, fd);
     }
 
     #[test]
@@ -549,8 +529,7 @@ mod tests {
         let fd = fs.open(b"/usr/empty").unwrap();
         let mut buf = [0u8; 8];
         assert_eq!(fs.read(fd, &mut buf), Some(0));
-        fs.close(fd);
-        unsafe { libc::close(fd) };
+        release(&fs, fd);
     }
 
     #[test]
@@ -562,8 +541,7 @@ mod tests {
         // A directory opens, but does not read.
         let fd = fs.open(b"/usr/bin").unwrap();
         assert_eq!(fs.read(fd, &mut [0u8; 8]), None);
-        fs.close(fd);
-        unsafe { libc::close(fd) };
+        release(&fs, fd);
     }
 
     #[test]
@@ -605,7 +583,6 @@ mod tests {
         assert_eq!(st.st_dev, DEV);
 
         assert_eq!(fs.stat(b"/nonexistent", &mut st), None);
-        assert_eq!(fs.lstat(b"/usr/bin/ls", &mut st), Some(0));
     }
 
     #[test]
@@ -622,8 +599,7 @@ mod tests {
         assert_eq!(by_fd.st_size, 16);
         assert_eq!(fs.fstat(9999, &mut by_fd), None);
 
-        fs.close(fd);
-        unsafe { libc::close(fd) };
+        release(&fs, fd);
     }
 
     #[test]
@@ -775,17 +751,6 @@ mod tests {
         fs.closedir(&dir);
         assert!(fs.readdir(&mut dir).is_none());
         unsafe { libc::close(fd) };
-    }
-
-    #[test]
-    fn file_read_returns_the_body() {
-        let fs = fs();
-        let ptr = fs.file_read(b"/usr/bin/ls").unwrap();
-        let body = unsafe { std::slice::from_raw_parts(ptr, 10) };
-        assert_eq!(body, b"ls_content");
-        assert!(fs.file_read(b"/nonexistent").is_none());
-        // A directory has no body.
-        assert!(fs.file_read(b"/usr/bin").is_none());
     }
 
     #[test]

--- a/kompo_tree/src/tree.rs
+++ b/kompo_tree/src/tree.rs
@@ -1,0 +1,427 @@
+//! Flat arena over the embedded path table.
+//!
+//! The generated C data gives us two index-aligned blobs: `PATHS` (NUL
+//! separated paths) and `FILES` (concatenated bodies, sliced by `FILES_SIZES`).
+//! This module turns the first into a tree without giving up that alignment:
+//! node ids are handed out in `PATHS` order, so a node id, its path bytes and
+//! its file body all sit at corresponding positions in their arrays.
+//!
+//! Path resolution goes through one hash of the whole path. That costs a single
+//! independent random access instead of one dependent load per component, which
+//! measures several times faster than walking the arena even though the walk
+//! has better locality. The walk is kept for the spellings the hash cannot
+//! answer (`..`, `//`, trailing slash).
+
+use rustc_hash::FxHashMap;
+use std::cmp::Ordering;
+
+/// Index into the node arena. Node 0 is always the root directory.
+pub type NodeId = u32;
+
+/// The root directory.
+pub const ROOT: NodeId = 0;
+
+/// `file_idx` of a directory: it has no body in `FILES`.
+const NO_FILE: u32 = u32::MAX;
+/// `name_slot` of the root: it is nobody's child.
+const NO_SLOT: u32 = u32::MAX;
+
+#[derive(Clone, Copy, Debug)]
+struct Node {
+    parent: NodeId,
+    /// Slot in `children` where this node's own name lives.
+    name_slot: u32,
+    /// Range in `children` holding this node's entries.
+    child_start: u32,
+    child_len: u32,
+    /// Index into `file_offsets`, or `NO_FILE` for a directory.
+    file_idx: u32,
+}
+
+pub struct Tree<'a> {
+    nodes: Box<[Node]>,
+    /// Child ids grouped by parent, each group sorted by name.
+    children: Box<[NodeId]>,
+    /// Offsets into `name_blob`, aligned with `children` (len = children + 1).
+    name_off: Box<[u32]>,
+    /// Child names in slot order, so one directory's names are contiguous.
+    name_blob: Box<[u8]>,
+    /// Canonical absolute path -> node. Keys borrow the caller's path blob.
+    by_path: FxHashMap<&'a [u8], NodeId>,
+    files: &'a [u8],
+    file_offsets: &'a [u64],
+}
+
+impl<'a> Tree<'a> {
+    /// Build from the embedded blobs.
+    ///
+    /// `paths` is NUL separated, `file_offsets` has one more entry than there
+    /// are paths, and body `i` is `files[file_offsets[i]..file_offsets[i + 1]]`.
+    pub fn build(paths: &'a [u8], files: &'a [u8], file_offsets: &'a [u64]) -> Self {
+        let mut nodes = vec![Node {
+            parent: ROOT,
+            name_slot: NO_SLOT,
+            child_start: 0,
+            child_len: 0,
+            file_idx: NO_FILE,
+        }];
+        let mut kids: Vec<Vec<NodeId>> = vec![Vec::new()];
+        let mut names: Vec<&'a [u8]> = vec![&[]];
+        let mut by_component: FxHashMap<(NodeId, &'a [u8]), NodeId> = FxHashMap::default();
+        let mut by_path: FxHashMap<&'a [u8], NodeId> = FxHashMap::default();
+        by_path.insert(b"/", ROOT);
+
+        // Entries are visited in blob order, so node ids follow PATHS order.
+        for (file_idx, entry) in split_paths(paths).enumerate() {
+            if entry.is_empty() {
+                continue; // keeps file_idx aligned with file_offsets
+            }
+
+            let mut cur = ROOT;
+            let mut i = 0usize;
+            while i < entry.len() {
+                while i < entry.len() && entry[i] == b'/' {
+                    i += 1;
+                }
+                if i >= entry.len() {
+                    break;
+                }
+                let start = i;
+                while i < entry.len() && entry[i] != b'/' {
+                    i += 1;
+                }
+                let comp = &entry[start..i];
+
+                cur = match by_component.get(&(cur, comp)) {
+                    Some(&id) => id,
+                    None => {
+                        let id = nodes.len() as NodeId;
+                        nodes.push(Node {
+                            parent: cur,
+                            name_slot: NO_SLOT,
+                            child_start: 0,
+                            child_len: 0,
+                            file_idx: NO_FILE,
+                        });
+                        kids.push(Vec::new());
+                        names.push(comp);
+                        kids[cur as usize].push(id);
+                        by_component.insert((cur, comp), id);
+                        id
+                    }
+                };
+
+                // `entry[..i]` is the absolute path of the node we just reached.
+                by_path.entry(&entry[..i]).or_insert(cur);
+            }
+
+            // The component the loop ended on is the file itself.
+            if cur != ROOT {
+                nodes[cur as usize].file_idx = file_idx as u32;
+            }
+        }
+
+        // Flatten the per-parent lists into one array. Parents are still in
+        // PATHS order, so sibling groups stay grouped by gem as emitted.
+        let mut children: Vec<NodeId> = Vec::with_capacity(nodes.len());
+        let mut name_blob: Vec<u8> = Vec::new();
+        let mut name_off: Vec<u32> = vec![0];
+        for parent in 0..nodes.len() {
+            let mut group = std::mem::take(&mut kids[parent]);
+            group.sort_unstable_by(|&x, &y| names[x as usize].cmp(names[y as usize]));
+
+            nodes[parent].child_start = children.len() as u32;
+            nodes[parent].child_len = group.len() as u32;
+            for id in group {
+                nodes[id as usize].name_slot = children.len() as u32;
+                children.push(id);
+                name_blob.extend_from_slice(names[id as usize]);
+                name_off.push(name_blob.len() as u32);
+            }
+        }
+
+        Tree {
+            nodes: nodes.into_boxed_slice(),
+            children: children.into_boxed_slice(),
+            name_off: name_off.into_boxed_slice(),
+            name_blob: name_blob.into_boxed_slice(),
+            by_path,
+            files,
+            file_offsets,
+        }
+    }
+
+    /// Resolve an absolute path.
+    ///
+    /// Canonical spellings are answered by a single hash probe. Anything else
+    /// falls back to walking the arena, which also handles `.` and `..`.
+    #[inline]
+    pub fn lookup(&self, path: &[u8]) -> Option<NodeId> {
+        if let Some(&id) = self.by_path.get(path) {
+            return Some(id);
+        }
+        // Every canonical path is in the index, so a miss here is a real ENOENT
+        // and must not pay for a second traversal -- that is the hot case
+        // during `require`, which probes far more names than it finds.
+        if is_canonical(path) {
+            return None;
+        }
+        self.lookup_walk(path)
+    }
+
+    /// Resolve by walking the arena one component at a time.
+    pub fn lookup_walk(&self, path: &[u8]) -> Option<NodeId> {
+        let mut cur = ROOT;
+        for comp in path.split(|&b| b == b'/') {
+            match comp {
+                b"" | b"." => continue,
+                b".." => cur = self.nodes.get(cur as usize)?.parent,
+                _ => cur = self.child(cur, comp)?,
+            }
+        }
+        Some(cur)
+    }
+
+    /// Look up a single entry in a directory.
+    #[inline]
+    pub fn child(&self, dir: NodeId, name: &[u8]) -> Option<NodeId> {
+        let node = self.nodes.get(dir as usize)?;
+        let base = node.child_start as usize;
+        let (mut lo, mut hi) = (0usize, node.child_len as usize);
+        while lo < hi {
+            let mid = lo + (hi - lo) / 2;
+            match self.slot_name(base + mid)?.cmp(name) {
+                Ordering::Less => lo = mid + 1,
+                Ordering::Greater => hi = mid,
+                Ordering::Equal => return self.children.get(base + mid).copied(),
+            }
+        }
+        None
+    }
+
+    #[inline]
+    fn slot_name(&self, slot: usize) -> Option<&[u8]> {
+        let start = *self.name_off.get(slot)? as usize;
+        let end = *self.name_off.get(slot + 1)? as usize;
+        self.name_blob.get(start..end)
+    }
+
+    #[inline]
+    pub fn is_dir(&self, id: NodeId) -> bool {
+        self.nodes
+            .get(id as usize)
+            .is_some_and(|n| n.file_idx == NO_FILE)
+    }
+
+    #[inline]
+    pub fn exists(&self, id: NodeId) -> bool {
+        (id as usize) < self.nodes.len()
+    }
+
+    /// File body, or `None` for a directory.
+    #[inline]
+    pub fn data(&self, id: NodeId) -> Option<&'a [u8]> {
+        let idx = self.nodes.get(id as usize)?.file_idx;
+        if idx == NO_FILE {
+            return None;
+        }
+        let start = *self.file_offsets.get(idx as usize)? as usize;
+        let end = *self.file_offsets.get(idx as usize + 1)? as usize;
+        self.files.get(start..end)
+    }
+
+    /// Basename. The root reports `/`.
+    #[inline]
+    pub fn name(&self, id: NodeId) -> &[u8] {
+        match self.nodes.get(id as usize) {
+            Some(n) if n.name_slot != NO_SLOT => {
+                self.slot_name(n.name_slot as usize).unwrap_or(&[])
+            }
+            Some(_) => b"/",
+            None => &[],
+        }
+    }
+
+    #[inline]
+    pub fn parent(&self, id: NodeId) -> NodeId {
+        self.nodes.get(id as usize).map_or(ROOT, |n| n.parent)
+    }
+
+    #[inline]
+    pub fn child_count(&self, dir: NodeId) -> u32 {
+        self.nodes.get(dir as usize).map_or(0, |n| n.child_len)
+    }
+
+    /// `index`-th entry of `dir`, in name order.
+    #[inline]
+    pub fn child_at(&self, dir: NodeId, index: u32) -> Option<NodeId> {
+        let node = self.nodes.get(dir as usize)?;
+        if index >= node.child_len {
+            return None;
+        }
+        self.children
+            .get(node.child_start as usize + index as usize)
+            .copied()
+    }
+
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Bytes held by the arena itself, excluding the borrowed blobs.
+    pub fn heap_bytes(&self) -> usize {
+        self.nodes.len() * std::mem::size_of::<Node>()
+            + self.children.len() * 4
+            + self.name_off.len() * 4
+            + self.name_blob.len()
+            + self.by_path.len() * (std::mem::size_of::<(&[u8], NodeId)>() + 1)
+    }
+}
+
+/// Split the NUL separated path blob, dropping the terminator.
+fn split_paths(blob: &[u8]) -> impl Iterator<Item = &[u8]> {
+    blob.split_inclusive(|&b| b == 0).map(|entry| {
+        if entry.last() == Some(&0) {
+            &entry[..entry.len() - 1]
+        } else {
+            entry
+        }
+    })
+}
+
+/// Is this path spelled exactly the way the index stores it?
+///
+/// Only canonical paths are guaranteed present, so this is what lets a hash
+/// miss be reported as ENOENT without a fallback traversal.
+fn is_canonical(path: &[u8]) -> bool {
+    if path.first() != Some(&b'/') {
+        return false;
+    }
+    if path == b"/" {
+        return true;
+    }
+    if path.last() == Some(&b'/') {
+        return false;
+    }
+    path[1..]
+        .split(|&b| b == b'/')
+        .all(|comp| !comp.is_empty() && comp != b"." && comp != b"..")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tree() -> Tree<'static> {
+        // "/usr/bin/ls", "/usr/bin/cat", "/usr/bin/hoge/fuga", "/usr/empty"
+        let paths: &'static [u8] = b"/usr/bin/ls\0/usr/bin/cat\0/usr/bin/hoge/fuga\0/usr/empty\0";
+        let files: &'static [u8] = b"LSCATFUGA";
+        let offsets: &'static [u64] = &[0, 2, 5, 9, 9];
+        Tree::build(paths, files, offsets)
+    }
+
+    #[test]
+    fn resolves_files_and_directories() {
+        let t = tree();
+        let ls = t.lookup(b"/usr/bin/ls").unwrap();
+        assert_eq!(t.data(ls), Some(&b"LS"[..]));
+        assert!(!t.is_dir(ls));
+
+        let bin = t.lookup(b"/usr/bin").unwrap();
+        assert!(t.is_dir(bin));
+        assert_eq!(t.data(bin), None);
+
+        assert!(t.is_dir(t.lookup(b"/").unwrap()));
+        assert!(t.is_dir(t.lookup(b"/usr/bin/hoge").unwrap()));
+    }
+
+    #[test]
+    fn empty_file_is_a_file_not_a_directory() {
+        let t = tree();
+        let empty = t.lookup(b"/usr/empty").unwrap();
+        assert!(!t.is_dir(empty));
+        assert_eq!(t.data(empty), Some(&b""[..]));
+    }
+
+    #[test]
+    fn misses_are_reported() {
+        let t = tree();
+        assert_eq!(t.lookup(b"/usr/bin/nope"), None);
+        assert_eq!(t.lookup(b"/nope"), None);
+        assert_eq!(t.lookup(b"/usr/bin/ls/deeper"), None);
+    }
+
+    #[test]
+    fn non_canonical_spellings_still_resolve() {
+        let t = tree();
+        let ls = t.lookup(b"/usr/bin/ls").unwrap();
+        assert_eq!(t.lookup(b"/usr//bin/ls"), Some(ls));
+        assert_eq!(t.lookup(b"/usr/bin/./ls"), Some(ls));
+        assert_eq!(t.lookup(b"/usr/bin/hoge/../ls"), Some(ls));
+        assert_eq!(t.lookup(b"/usr/bin/"), t.lookup(b"/usr/bin"));
+        assert_eq!(t.lookup(b"/usr/bin/../../usr/bin/ls"), Some(ls));
+    }
+
+    #[test]
+    fn entries_are_sorted_and_complete() {
+        let t = tree();
+        let bin = t.lookup(b"/usr/bin").unwrap();
+        let names: Vec<&[u8]> = (0..t.child_count(bin))
+            .map(|i| t.name(t.child_at(bin, i).unwrap()))
+            .collect();
+        assert_eq!(names, vec![&b"cat"[..], b"hoge", b"ls"]);
+        assert_eq!(t.child_at(bin, 3), None);
+    }
+
+    #[test]
+    fn parent_links_reach_the_root() {
+        let t = tree();
+        let fuga = t.lookup(b"/usr/bin/hoge/fuga").unwrap();
+        let hoge = t.parent(fuga);
+        assert_eq!(t.name(hoge), b"hoge");
+        assert_eq!(t.name(t.parent(hoge)), b"bin");
+        assert_eq!(t.parent(ROOT), ROOT);
+        assert_eq!(t.name(ROOT), b"/");
+    }
+
+    #[test]
+    fn node_ids_follow_paths_order() {
+        // The first path's leaf must get a lower id than the last path's leaf:
+        // this is the property that keeps the arena aligned with FILES.
+        let t = tree();
+        let first = t.lookup(b"/usr/bin/ls").unwrap();
+        let last = t.lookup(b"/usr/empty").unwrap();
+        assert!(first < last);
+    }
+
+    #[test]
+    fn canonical_form_detection() {
+        assert!(is_canonical(b"/"));
+        assert!(is_canonical(b"/a/b.rb"));
+        assert!(!is_canonical(b"a/b.rb"));
+        assert!(!is_canonical(b"/a//b.rb"));
+        assert!(!is_canonical(b"/a/b/"));
+        assert!(!is_canonical(b"/a/./b"));
+        assert!(!is_canonical(b"/a/../b"));
+    }
+
+    #[test]
+    fn tolerates_a_blob_without_a_trailing_nul() {
+        let paths: &'static [u8] = b"/a.rb\0/b.rb";
+        let files: &'static [u8] = b"AB";
+        let offsets: &'static [u64] = &[0, 1, 2];
+        let t = Tree::build(paths, files, offsets);
+        assert_eq!(t.data(t.lookup(b"/a.rb").unwrap()), Some(&b"A"[..]));
+        assert_eq!(t.data(t.lookup(b"/b.rb").unwrap()), Some(&b"B"[..]));
+    }
+
+    #[test]
+    fn truncated_offsets_do_not_panic() {
+        let paths: &'static [u8] = b"/a.rb\0/b.rb\0";
+        let files: &'static [u8] = b"AB";
+        let offsets: &'static [u64] = &[0, 1]; // one short
+        let t = Tree::build(paths, files, offsets);
+        assert_eq!(t.data(t.lookup(b"/a.rb").unwrap()), Some(&b"A"[..]));
+        assert_eq!(t.data(t.lookup(b"/b.rb").unwrap()), None);
+    }
+}

--- a/kompo_tree/src/tree.rs
+++ b/kompo_tree/src/tree.rs
@@ -107,34 +107,25 @@ impl<'a> Tree<'a> {
             }
 
             let mut cur = ROOT;
-            let mut i = 0usize;
-            // Decided while walking rather than by a second pass over the
-            // bytes, which showed up as a fifth of the build time.
-            let mut canonical = entry[0] == b'/';
-            while i < entry.len() {
-                let slashes = i;
-                while i < entry.len() && entry[i] == b'/' {
-                    i += 1;
-                }
-                if i - slashes > 1 {
-                    canonical = false; // a "//" run
-                }
-                if i >= entry.len() {
-                    if i > slashes && cur != ROOT {
-                        canonical = false; // a trailing "/"
-                    }
-                    break;
-                }
-                let start = i;
-                while i < entry.len() && entry[i] != b'/' {
-                    i += 1;
-                }
-                let comp = &entry[start..i];
+            // Canonicality is decided while walking rather than by a second
+            // pass over the bytes, which measured a fifth of the build time.
+            let mut canonical = entry.first() == Some(&b'/');
+            let mut end = 0usize;
+
+            for (nth, comp) in entry.split(|&b| b == b'/').enumerate() {
+                end += comp.len() + usize::from(nth > 0); // index just past `comp`
 
                 // Resolve the way a lookup would, so an oddly spelled entry
                 // lands on the node it names instead of creating a node
                 // literally called "." or "..".
                 match comp {
+                    // Only the leading separator may leave an empty component.
+                    // Anything later is a "//" run or a trailing slash, except
+                    // in the bare root, whose sole component is its separator.
+                    b"" => {
+                        canonical &= nth == 0 || entry.len() == 1;
+                        continue;
+                    }
                     b"." => {
                         canonical = false;
                         continue;
@@ -166,11 +157,11 @@ impl<'a> Tree<'a> {
                     }
                 };
 
-                // `entry[..i]` is the absolute path of the node we just reached.
-                by_path.entry(&entry[..i]).or_insert(cur);
+                // `entry[..end]` is the absolute path of the node we just reached.
+                by_path.entry(&entry[..end]).or_insert(cur);
             }
 
-            // The component the loop ended on is the file itself.
+            // The component the walk ended on is the file itself.
             if cur != ROOT {
                 nodes[cur as usize].file_idx = file_idx as u32;
             }
@@ -237,12 +228,12 @@ impl<'a> Tree<'a> {
     }
 
     /// Resolve by walking the arena one component at a time.
-    pub fn lookup_walk(&self, path: &[u8]) -> Option<NodeId> {
+    fn lookup_walk(&self, path: &[u8]) -> Option<NodeId> {
         let mut cur = ROOT;
         for comp in path.split(|&b| b == b'/') {
             match comp {
                 b"" | b"." => continue,
-                b".." => cur = self.nodes.get(cur as usize)?.parent,
+                b".." => cur = self.parent(cur),
                 _ => cur = self.child(cur, comp)?,
             }
         }
@@ -251,7 +242,7 @@ impl<'a> Tree<'a> {
 
     /// Look up a single entry in a directory.
     #[inline]
-    pub fn child(&self, dir: NodeId, name: &[u8]) -> Option<NodeId> {
+    fn child(&self, dir: NodeId, name: &[u8]) -> Option<NodeId> {
         let node = self.nodes.get(dir as usize)?;
         let base = node.child_start as usize;
         let (mut lo, mut hi) = (0usize, node.child_len as usize);
@@ -314,11 +305,6 @@ impl<'a> Tree<'a> {
         self.nodes.get(id as usize).map_or(ROOT, |n| n.parent)
     }
 
-    #[inline]
-    pub fn child_count(&self, dir: NodeId) -> u32 {
-        self.nodes.get(dir as usize).map_or(0, |n| n.child_len)
-    }
-
     /// `index`-th entry of `dir`, in name order.
     #[inline]
     pub fn child_at(&self, dir: NodeId, index: u32) -> Option<NodeId> {
@@ -330,19 +316,14 @@ impl<'a> Tree<'a> {
             .get(node.child_start as usize + index as usize)
             .copied()
     }
+}
 
-    pub fn node_count(&self) -> usize {
-        self.nodes.len()
-    }
-
-    /// Bytes held by the arena itself, excluding the borrowed blobs.
-    pub fn heap_bytes(&self) -> usize {
-        self.nodes.len() * std::mem::size_of::<Node>()
-            + self.children.len() * 4
-            + self.name_off.len() * 4
-            + self.name_blob.len()
-            + self.by_path.len() * (std::mem::size_of::<(&[u8], NodeId)>() + 1)
-    }
+/// Number of entries in a NUL separated path blob.
+///
+/// `FILES_SIZES` has one more entry than this. Exposed so the framing
+/// convention lives here rather than being re-derived by every caller.
+pub fn path_count(paths: &[u8]) -> usize {
+    split_paths(paths).count()
 }
 
 /// Split the NUL separated path blob, dropping the terminator.
@@ -433,8 +414,9 @@ mod tests {
     fn entries_are_sorted_and_complete() {
         let t = tree();
         let bin = t.lookup(b"/usr/bin").unwrap();
-        let names: Vec<&[u8]> = (0..t.child_count(bin))
-            .map(|i| t.name(t.child_at(bin, i).unwrap()))
+        let names: Vec<&[u8]> = (0..)
+            .map_while(|i| t.child_at(bin, i))
+            .map(|id| t.name(id))
             .collect();
         assert_eq!(names, vec![&b"cat"[..], b"hoge", b"ls"]);
         assert_eq!(t.child_at(bin, 3), None);
@@ -459,6 +441,37 @@ mod tests {
         let first = t.lookup(b"/usr/bin/ls").unwrap();
         let last = t.lookup(b"/usr/empty").unwrap();
         assert!(first < last);
+    }
+
+    /// `lookup`'s short-circuit is only sound while the verdict `build` reaches
+    /// while walking agrees with the standalone `is_canonical`. They are
+    /// written differently for speed, so pin them to each other.
+    #[test]
+    fn build_agrees_with_is_canonical() {
+        for entry in [
+            &b"/a/b.rb"[..],
+            b"/a",
+            b"/",
+            b"a/b.rb",
+            b"/a//b.rb",
+            b"//a/b.rb",
+            b"/a/./b.rb",
+            b"/a/../b.rb",
+            b"/a/b/",
+            b"/a/b//",
+        ] {
+            let mut blob = entry.to_vec();
+            blob.push(0);
+            let blob: &'static [u8] = Vec::leak(blob);
+
+            let tree = Tree::build(blob, b"", &[0, 0]);
+            assert_eq!(
+                tree.paths_are_canonical(),
+                is_canonical(entry),
+                "disagreed on {:?}",
+                std::str::from_utf8(entry).unwrap()
+            );
+        }
     }
 
     #[test]
@@ -526,8 +539,9 @@ mod tests {
 
         // ...no bogus "." or ".." node was created...
         let a = t.lookup(b"/a").unwrap();
-        let names: Vec<&[u8]> = (0..t.child_count(a))
-            .map(|i| t.name(t.child_at(a, i).unwrap()))
+        let names: Vec<&[u8]> = (0..)
+            .map_while(|i| t.child_at(a, i))
+            .map(|id| t.name(id))
             .collect();
         assert_eq!(names, vec![&b"b.rb"[..], b"c.rb", b"d.rb", b"x"]);
 

--- a/kompo_tree/src/tree.rs
+++ b/kompo_tree/src/tree.rs
@@ -93,7 +93,6 @@ impl<'a> Tree<'a> {
             child_len: 0,
             file_idx: NO_FILE,
         }];
-        let mut kids: Vec<Vec<NodeId>> = vec![Vec::new()];
         let mut names: Vec<&'a [u8]> = vec![&[]];
         let mut by_component: FxHashMap<(NodeId, &'a [u8]), NodeId> = FxHashMap::default();
         let mut by_path: FxHashMap<&'a [u8], NodeId> = FxHashMap::default();
@@ -149,16 +148,16 @@ impl<'a> Tree<'a> {
                             child_len: 0,
                             file_idx: NO_FILE,
                         });
-                        kids.push(Vec::new());
                         names.push(comp);
-                        kids[cur as usize].push(id);
                         by_component.insert((cur, comp), id);
+                        // `entry[..end]` is this node's absolute path. Recording
+                        // it only where the node is created is what keeps a
+                        // directory prefix from being hashed once per file
+                        // beneath it.
+                        by_path.insert(&entry[..end], id);
                         id
                     }
                 };
-
-                // `entry[..end]` is the absolute path of the node we just reached.
-                by_path.entry(&entry[..end]).or_insert(cur);
             }
 
             // The component the walk ended on is the file itself.
@@ -168,23 +167,43 @@ impl<'a> Tree<'a> {
             all_canonical &= canonical;
         }
 
-        // Flatten the per-parent lists into one array. Parents are still in
-        // PATHS order, so sibling groups stay grouped by gem as emitted.
-        let mut children: Vec<NodeId> = Vec::with_capacity(nodes.len());
-        let mut name_blob: Vec<u8> = Vec::new();
-        let mut name_off: Vec<u32> = vec![0];
-        for parent in 0..nodes.len() {
-            let mut group = std::mem::take(&mut kids[parent]);
-            group.sort_unstable_by(|&x, &y| names[x as usize].cmp(names[y as usize]));
+        // Group the children by parent: count, prefix-sum into `child_start`,
+        // then scatter. That is the standard way to build the CSR layout, and
+        // it replaces a heap-allocated child list per directory.
+        for id in 1..nodes.len() {
+            let parent = nodes[id].parent as usize;
+            nodes[parent].child_len += 1;
+        }
+        let mut next_slot = 0u32;
+        for node in nodes.iter_mut() {
+            node.child_start = next_slot;
+            next_slot += node.child_len;
+        }
 
-            nodes[parent].child_start = children.len() as u32;
-            nodes[parent].child_len = group.len() as u32;
-            for id in group {
-                nodes[id as usize].name_slot = children.len() as u32;
-                children.push(id);
-                name_blob.extend_from_slice(names[id as usize]);
-                name_off.push(name_blob.len() as u32);
-            }
+        let mut cursor: Vec<u32> = nodes.iter().map(|n| n.child_start).collect();
+        // Every node but the root is exactly one parent's child.
+        let mut children: Vec<NodeId> = vec![ROOT; nodes.len() - 1];
+        for (id, node) in nodes.iter().enumerate().skip(1) {
+            let parent = node.parent as usize;
+            children[cursor[parent] as usize] = id as NodeId;
+            cursor[parent] += 1;
+        }
+
+        // Parents are still in PATHS order, so sibling groups stay grouped by
+        // source tree as emitted; sorting only orders within one group.
+        for node in nodes.iter() {
+            let start = node.child_start as usize;
+            let group = &mut children[start..start + node.child_len as usize];
+            group.sort_unstable_by_key(|&id| names[id as usize]);
+        }
+
+        let mut name_blob: Vec<u8> = Vec::new();
+        let mut name_off: Vec<u32> = Vec::with_capacity(children.len() + 1);
+        name_off.push(0);
+        for (slot, &id) in children.iter().enumerate() {
+            nodes[id as usize].name_slot = slot as u32;
+            name_blob.extend_from_slice(names[id as usize]);
+            name_off.push(name_blob.len() as u32);
         }
 
         Tree {

--- a/kompo_tree/src/tree.rs
+++ b/kompo_tree/src/tree.rs
@@ -18,7 +18,6 @@ use std::cmp::Ordering;
 /// Index into the node arena. Node 0 is always the root directory.
 pub type NodeId = u32;
 
-/// The root directory.
 pub const ROOT: NodeId = 0;
 
 /// `file_idx` of a directory: it has no body in `FILES`.
@@ -112,7 +111,7 @@ impl<'a> Tree<'a> {
             let mut end = 0usize;
 
             for (nth, comp) in entry.split(|&b| b == b'/').enumerate() {
-                end += comp.len() + usize::from(nth > 0); // index just past `comp`
+                end += comp.len() + usize::from(nth > 0); // the separator is not part of `comp`
 
                 // Resolve the way a lookup would, so an oddly spelled entry
                 // lands on the node it names instead of creating a node
@@ -167,9 +166,9 @@ impl<'a> Tree<'a> {
             all_canonical &= canonical;
         }
 
-        // Group the children by parent: count, prefix-sum into `child_start`,
-        // then scatter. That is the standard way to build the CSR layout, and
-        // it replaces a heap-allocated child list per directory.
+        // Counting sort into the CSR arrays. Collecting each directory's
+        // children into its own vector first would cost a heap allocation per
+        // directory, all of it discarded once the groups are contiguous.
         for id in 1..nodes.len() {
             let parent = nodes[id].parent as usize;
             nodes[parent].child_len += 1;
@@ -246,7 +245,7 @@ impl<'a> Tree<'a> {
         self.lookup_walk(path)
     }
 
-    /// Resolve by walking the arena one component at a time.
+    /// Fallback for the spellings `by_path` cannot answer.
     fn lookup_walk(&self, path: &[u8]) -> Option<NodeId> {
         let mut cur = ROOT;
         for comp in path.split(|&b| b == b'/') {
@@ -259,7 +258,6 @@ impl<'a> Tree<'a> {
         Some(cur)
     }
 
-    /// Look up a single entry in a directory.
     #[inline]
     fn child(&self, dir: NodeId, name: &[u8]) -> Option<NodeId> {
         let node = self.nodes.get(dir as usize)?;
@@ -380,7 +378,6 @@ mod tests {
     use super::*;
 
     fn tree() -> Tree<'static> {
-        // "/usr/bin/ls", "/usr/bin/cat", "/usr/bin/hoge/fuga", "/usr/empty"
         let paths: &'static [u8] = b"/usr/bin/ls\0/usr/bin/cat\0/usr/bin/hoge/fuga\0/usr/empty\0";
         let files: &'static [u8] = b"LSCATFUGA";
         let offsets: &'static [u64] = &[0, 2, 5, 9, 9];
@@ -551,12 +548,10 @@ mod tests {
 
         assert!(!t.paths_are_canonical());
 
-        // Each one is reachable under the spelling a caller would use...
         assert_eq!(t.data(t.lookup(b"/a/b.rb").unwrap()), Some(&b"B"[..]));
         assert_eq!(t.data(t.lookup(b"/a/c.rb").unwrap()), Some(&b"C"[..]));
         assert_eq!(t.data(t.lookup(b"/a/d.rb").unwrap()), Some(&b"D"[..]));
 
-        // ...no bogus "." or ".." node was created...
         let a = t.lookup(b"/a").unwrap();
         let names: Vec<&[u8]> = (0..)
             .map_while(|i| t.child_at(a, i))
@@ -564,7 +559,6 @@ mod tests {
             .collect();
         assert_eq!(names, vec![&b"b.rb"[..], b"c.rb", b"d.rb", b"x"]);
 
-        // ...and a genuine miss is still a miss.
         assert_eq!(t.lookup(b"/a/nope.rb"), None);
     }
 

--- a/kompo_tree/src/tree.rs
+++ b/kompo_tree/src/tree.rs
@@ -48,6 +48,15 @@ pub struct Tree<'a> {
     name_blob: Box<[u8]>,
     /// Canonical absolute path -> node. Keys borrow the caller's path blob.
     by_path: FxHashMap<&'a [u8], NodeId>,
+    /// Was every entry in the path blob spelled canonically?
+    ///
+    /// The generator guarantees it is (see [`Tree::build`]), and when it holds,
+    /// `by_path` contains every path under the spelling a caller will use, so a
+    /// miss is a real ENOENT. If a future generator ever emits `/a//b.rb`, that
+    /// node would only be reachable under the odd spelling, and answering a
+    /// canonical query from the index alone would be a false ENOENT. Dropping
+    /// the short-circuit in that case costs a walk per miss and stays correct.
+    all_canonical: bool,
     files: &'a [u8],
     file_offsets: &'a [u64],
 }
@@ -57,6 +66,25 @@ impl<'a> Tree<'a> {
     ///
     /// `paths` is NUL separated, `file_offsets` has one more entry than there
     /// are paths, and body `i` is `files[file_offsets[i]..file_offsets[i + 1]]`.
+    ///
+    /// What the kompo generator guarantees about `paths`, which this relies on:
+    ///
+    /// * every entry is an absolute canonical path -- it passes through
+    ///   `File.expand_path`, so no `//`, no `.` or `..`, no trailing slash;
+    /// * only files appear, never directories, so a node with children is a
+    ///   directory and nothing else;
+    /// * entries are grouped by source tree, which is what makes node ids track
+    ///   the layout of `FILES`;
+    /// * the blob always ends with a NUL, which `split_paths` absorbs without
+    ///   producing a trailing empty entry.
+    ///
+    /// Symlinks are *not* resolved by the generator, so one file can appear
+    /// under two paths. Those become two nodes with two inodes, matching what
+    /// the trie in `kompo_storage` does.
+    ///
+    /// None of these are assumed blindly: odd spellings are normalised below
+    /// and recorded in `all_canonical`, so a generator change degrades speed
+    /// rather than correctness.
     pub fn build(paths: &'a [u8], files: &'a [u8], file_offsets: &'a [u64]) -> Self {
         let mut nodes = vec![Node {
             parent: ROOT,
@@ -72,6 +100,7 @@ impl<'a> Tree<'a> {
         by_path.insert(b"/", ROOT);
 
         // Entries are visited in blob order, so node ids follow PATHS order.
+        let mut all_canonical = true;
         for (file_idx, entry) in split_paths(paths).enumerate() {
             if entry.is_empty() {
                 continue; // keeps file_idx aligned with file_offsets
@@ -79,11 +108,21 @@ impl<'a> Tree<'a> {
 
             let mut cur = ROOT;
             let mut i = 0usize;
+            // Decided while walking rather than by a second pass over the
+            // bytes, which showed up as a fifth of the build time.
+            let mut canonical = entry[0] == b'/';
             while i < entry.len() {
+                let slashes = i;
                 while i < entry.len() && entry[i] == b'/' {
                     i += 1;
                 }
+                if i - slashes > 1 {
+                    canonical = false; // a "//" run
+                }
                 if i >= entry.len() {
+                    if i > slashes && cur != ROOT {
+                        canonical = false; // a trailing "/"
+                    }
                     break;
                 }
                 let start = i;
@@ -91,6 +130,22 @@ impl<'a> Tree<'a> {
                     i += 1;
                 }
                 let comp = &entry[start..i];
+
+                // Resolve the way a lookup would, so an oddly spelled entry
+                // lands on the node it names instead of creating a node
+                // literally called "." or "..".
+                match comp {
+                    b"." => {
+                        canonical = false;
+                        continue;
+                    }
+                    b".." => {
+                        canonical = false;
+                        cur = nodes[cur as usize].parent;
+                        continue;
+                    }
+                    _ => {}
+                }
 
                 cur = match by_component.get(&(cur, comp)) {
                     Some(&id) => id,
@@ -119,6 +174,7 @@ impl<'a> Tree<'a> {
             if cur != ROOT {
                 nodes[cur as usize].file_idx = file_idx as u32;
             }
+            all_canonical &= canonical;
         }
 
         // Flatten the per-parent lists into one array. Parents are still in
@@ -146,9 +202,19 @@ impl<'a> Tree<'a> {
             name_off: name_off.into_boxed_slice(),
             name_blob: name_blob.into_boxed_slice(),
             by_path,
+            all_canonical,
             files,
             file_offsets,
         }
+    }
+
+    /// Was every path in the blob spelled canonically?
+    ///
+    /// True for anything the kompo generator produces. Exposed so a change on
+    /// that side shows up as a failing assertion rather than as a slow lookup
+    /// nobody notices.
+    pub fn paths_are_canonical(&self) -> bool {
+        self.all_canonical
     }
 
     /// Resolve an absolute path.
@@ -162,8 +228,9 @@ impl<'a> Tree<'a> {
         }
         // Every canonical path is in the index, so a miss here is a real ENOENT
         // and must not pay for a second traversal -- that is the hot case
-        // during `require`, which probes far more names than it finds.
-        if is_canonical(path) {
+        // during `require`, which probes far more names than it finds. That
+        // only holds if the blob itself was canonical; see `all_canonical`.
+        if self.all_canonical && is_canonical(path) {
             return None;
         }
         self.lookup_walk(path)
@@ -403,6 +470,69 @@ mod tests {
         assert!(!is_canonical(b"/a/b/"));
         assert!(!is_canonical(b"/a/./b"));
         assert!(!is_canonical(b"/a/../b"));
+    }
+
+    /// The generator always terminates the last path too, so `PATHS_SIZE`
+    /// counts a final NUL. That must not shift `file_idx` off `FILES_SIZES`.
+    #[test]
+    fn trailing_nul_does_not_add_a_phantom_entry() {
+        let paths: &'static [u8] = b"/a.rb\0/b.rb\0";
+        let files: &'static [u8] = b"AABBB";
+        let offsets: &'static [u64] = &[0, 2, 5];
+        let t = Tree::build(paths, files, offsets);
+
+        assert_eq!(split_paths(paths).count(), 2);
+        assert_eq!(t.data(t.lookup(b"/a.rb").unwrap()), Some(&b"AA"[..]));
+        assert_eq!(t.data(t.lookup(b"/b.rb").unwrap()), Some(&b"BBB"[..]));
+    }
+
+    /// `main.c` embeds the entrypoint without normalising it, so `kompo -e
+    /// ./main.rb` asks for `/wd/./main.rb` while the blob holds `/wd/main.rb`.
+    #[test]
+    fn entrypoint_spelled_with_a_dot_still_resolves() {
+        let paths: &'static [u8] = b"/wd/main.rb\0";
+        let files: &'static [u8] = b"puts 1";
+        let offsets: &'static [u64] = &[0, 6];
+        let t = Tree::build(paths, files, offsets);
+
+        let main = t.lookup(b"/wd/main.rb").unwrap();
+        assert_eq!(t.lookup(b"/wd/./main.rb"), Some(main));
+        // The working directory is derived from that same string.
+        assert_eq!(t.lookup(b"/wd/."), t.lookup(b"/wd"));
+    }
+
+    #[test]
+    fn generator_output_is_recognised_as_canonical() {
+        let paths: &'static [u8] = b"/a/b.rb\0/a/c/d.rb\0";
+        let t = Tree::build(paths, b"XY", &[0, 1, 2]);
+        assert!(t.paths_are_canonical());
+    }
+
+    /// If the generator ever regresses, lookups must get slower, not wrong.
+    #[test]
+    fn odd_entries_in_the_blob_still_resolve_canonically() {
+        // A redundant slash, a dot component, and a parent component.
+        let paths: &'static [u8] = b"/a//b.rb\0/a/./c.rb\0/a/x/../d.rb\0";
+        let files: &'static [u8] = b"BCD";
+        let offsets: &'static [u64] = &[0, 1, 2, 3];
+        let t = Tree::build(paths, files, offsets);
+
+        assert!(!t.paths_are_canonical());
+
+        // Each one is reachable under the spelling a caller would use...
+        assert_eq!(t.data(t.lookup(b"/a/b.rb").unwrap()), Some(&b"B"[..]));
+        assert_eq!(t.data(t.lookup(b"/a/c.rb").unwrap()), Some(&b"C"[..]));
+        assert_eq!(t.data(t.lookup(b"/a/d.rb").unwrap()), Some(&b"D"[..]));
+
+        // ...no bogus "." or ".." node was created...
+        let a = t.lookup(b"/a").unwrap();
+        let names: Vec<&[u8]> = (0..t.child_count(a))
+            .map(|i| t.name(t.child_at(a, i).unwrap()))
+            .collect();
+        assert_eq!(names, vec![&b"b.rb"[..], b"c.rb", b"d.rb", b"x"]);
+
+        // ...and a genuine miss is still a miss.
+        assert_eq!(t.lookup(b"/a/nope.rb"), None);
     }
 
     #[test]


### PR DESCRIPTION
Path lookup through the trie in kompo_storage currently costs more than
the real filesystem it replaces: a stat is 5-19us against ~0.5us for a
page-cached stat(2), and listing a 40 entry directory takes 7.4ms.

Two things drive that. trie-rs allocates a Vec of sibling node numbers
at every path component, so cost grows with depth and directory width.
And directories are not stored: a directory stat runs a predictive
search over the whole subtree building an OsString per component, which
readdir then repeats for every entry to decide DT_REG vs DT_DIR.

kompo_tree keeps the same operations on a flat node arena instead:

- whole paths are indexed in one hash, so resolution is a single
  independent lookup rather than one dependent load per component. The
  arena walk is kept for spellings the index cannot answer (.., //,
  trailing slash), and canonical paths short-circuit to ENOENT so a
  miss never pays for a second traversal -- that is require's hot path.
- a directory owns a contiguous range of entries, so opendir is a
  lookup and readdir is an index. The dirent lives in the FsDir and is
  reused, which matches readdir(3) and drops the 280 bytes that leak
  per call today.
- node ids are handed out in PATHS order, keeping the arena aligned
  with the gem grouping already present in PATHS and FILES.
- uid/gid are read once instead of two syscalls per stat, and stat
  zeroes the caller's buffer so unset fields do not read as garbage.

Inodes become INO_BASE | node_id rather than a hash of the path
components. st_dev is what separates the VFS from the real filesystem
and is unchanged, but dirent carries a bare d_ino with no device field,
so the base keeps virtual inodes clear of the range a real filesystem
uses while the id below it stays dense and collision-free. It also ties
identity to the node rather than to how the path was spelled.

Measured against kompo_storage on the same 3,328 file image
(cargo bench -p kompo_tree):

  stat, depth 3      5.52us -> 20.1ns
  stat, depth 8      19.2us -> 16.8ns
  stat, miss         38.1us -> 45.7ns
  require cycle      37.7us -> 400ns
  readdir, 30 dirs    204us -> 931ns
  readdir, 203 dirs  4.54ms -> 4.53us
  readdir, 40 dirs   7.39ms -> 1.16us
  build index        1.66ms -> 890us

kompo_fs still uses kompo_storage; nothing is wired up yet. Paths are
taken as bytes rather than pre-split components, since every caller in
glue already holds an absolute path, and file_read reports a missing
path as None instead of panicking.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DqzQXQzCXJVj5Ty92STZcA