### PR TITLE
Make bump_version.sh work with GNU sed

### DIFF
--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -7,6 +7,14 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CARGO_TOML="$PROJECT_ROOT/Cargo.toml"
 FORMULA_FILE="$PROJECT_ROOT/Formula/kompo-vfs.rb"
 
+# GNU sed takes the -i suffix attached, BSD sed takes it as a separate
+# argument, so an invocation that works on one errors on the other.
+if sed --version >/dev/null 2>&1; then
+    sed_inplace() { sed -i "$@"; }
+else
+    sed_inplace() { sed -i '' "$@"; }
+fi
+
 CURRENT_VERSION=$(sed -n '/\[workspace\.package\]/,/^\[/{ s/^version = "\(.*\)"/\1/p; }' "$CARGO_TOML")
 
 if [ -z "$1" ]; then
@@ -22,11 +30,11 @@ NEW_VERSION="$1"
 echo "Updating version to $NEW_VERSION..."
 
 # Update workspace.package.version in root Cargo.toml
-sed -i '' "/\[workspace\.package\]/,/^\[/ s/^version = \".*\"/version = \"$NEW_VERSION\"/" "$CARGO_TOML"
+sed_inplace "/\[workspace\.package\]/,/^\[/ s/^version = \".*\"/version = \"$NEW_VERSION\"/" "$CARGO_TOML"
 echo "  Updated: Cargo.toml (workspace.package.version)"
 
 # Update Formula
-sed -i '' "s/^  version \".*\"/  version \"$NEW_VERSION\"/" "$FORMULA_FILE"
+sed_inplace "s/^  version \".*\"/  version \"$NEW_VERSION\"/" "$FORMULA_FILE"
 echo "  Updated: Formula/kompo-vfs.rb"
 
 echo ""


### PR DESCRIPTION
`sed -i ''` is BSD syntax. GNU sed takes the backup suffix attached to `-i`, so the empty argument is read as the script and the real script as a filename — the script only ever worked from macOS, and on Linux failed with an error that points at the wrong thing.

Both spellings now sit behind one helper, chosen by whether `sed` answers to `--version`. Verified by running it on Linux:

```
$ bash scripts/bump_version.sh 0.7.0
Updating version to 0.7.0...
  Updated: Cargo.toml (workspace.package.version)
  Updated: Formula/kompo-vfs.rb

Verify changes:
  Cargo.toml workspace version: 0.7.0
  Formula version: 0.7.0
```

No changelog entry here: this repo writes those on the `release/vX.Y.Z` branch alongside the version bump, so it belongs there rather than in this pull request.