### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-01
+
+### Added
+- Add `kompo_tree`, a flat-arena path index replacing the trie in `kompo_storage` [#24](https://github.com/ahogappa/kompo-vfs/pull/24)
+
+### Changed
+- Index the embedded image with `kompo_tree`: `stat` 4.0-15.7us -> ~11ns, `readdir` on a 40 entry directory 7.5ms -> 1.0us [#24](https://github.com/ahogappa/kompo-vfs/pull/24)
+- Handle paths as bytes throughout, so a filename that is not valid UTF-8 is looked up rather than panicked on [#24](https://github.com/ahogappa/kompo-vfs/pull/24)
+- Report inodes as `INO_BASE | node_id`, unique by construction and clear of the range a real filesystem uses [#24](https://github.com/ahogappa/kompo-vfs/pull/24)
+- Reuse the `dirent` owned by the `DIR` in `readdir`, matching `readdir(3)` and no longer leaking 280 bytes per call [#24](https://github.com/ahogappa/kompo-vfs/pull/24)
+- `kompo_storage` is no longer linked; it remains only as the benchmark baseline [#24](https://github.com/ahogappa/kompo-vfs/pull/24)
+
+### Fixed
+- Return a canonical path from `realpath` instead of the caller's spelling [#24](https://github.com/ahogappa/kompo-vfs/pull/24)
+- Stop claiming sibling directories whose name extends the working directory's [#24](https://github.com/ahogappa/kompo-vfs/pull/24)
+- Make `bump_version.sh` work with GNU sed as well as BSD sed [#25](https://github.com/ahogappa/kompo-vfs/pull/25)
+
 ## [0.6.0] - 2026-01-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "kompo_fs"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "errno",
  "kompo_fs_test_data",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "kompo_storage"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "libc",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "kompo_tree"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "kompo_storage",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "kompo_wrap"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "libc",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 
 [profile.release]
 panic = "abort"

--- a/Formula/kompo-vfs.rb
+++ b/Formula/kompo-vfs.rb
@@ -3,7 +3,7 @@ class KompoVfs < Formula
   homepage "https://github.com/ahogappa/kompo-vfs"
   url "https://github.com/ahogappa/kompo-vfs.git", using: :git, branch: "main"
   head "https://github.com/ahogappa/kompo-vfs.git", branch: "main"
-  version "0.6.0"
+  version "0.7.0"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
Version bump and changelog for 0.7.0, covering #24 and #25.

## Why minor and not major

The exported C ABI is unchanged. All 20 symbols (`open_from_fs`, `stat_from_fs`, `readdir_from_fs`, …) are byte-identical between 0.6.0 and this branch, so the kompo gem links against it without changes.

## What is in it

#24 replaced the trie index with `kompo_tree`, a flat node arena. Measured on the same 3,328 file image, from one `cargo bench -p kompo_tree` run:

| | 0.6.0 (trie) | 0.7.0 (tree) |
|---|---:|---:|
| `stat`, depth 3 | 4.04 µs | 10.2 ns |
| `stat`, depth 8 | 15.65 µs | 11.1 ns |
| `stat`, miss | 33.0 µs | 36.2 ns |
| `require` cycle | 34.8 µs | 359 ns |
| `readdir`, 30 entries | 152 µs | 807 ns |
| `readdir`, 203 entries | 3.68 ms | 3.53 µs |
| `readdir`, 40 entries | 7.49 ms | 991 ns |
| build the index | 1.34 ms | 653 µs |

It also carries two behaviour fixes — `realpath` now returns a canonical path, and the working-directory test no longer claims sibling directories whose name merely extends it — plus the end of a 280-byte-per-call leak in `readdir`. #25 made `bump_version.sh` usable from Linux, which is what produced this branch.

## Verified

- `KOMPO_VFS_VERSION` reads `0.7.0`, and `Formula/kompo-vfs.rb` matches. All four crates inherit `version.workspace`.
- Tests, `cargo fmt`, `clippy -D warnings` and `cargo build --release` clean.